### PR TITLE
Add support for building schemes and workspaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <relativePath/>
   </parent>
   <artifactId>xcode-plugin</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.0.2-FW-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>XCode integration</name>
   <description>This plugin adds the ability to call Xcode command line tools to automate build and packaging iOS applications (iPhone, iPad, ...).</description>

--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -59,6 +59,8 @@ public class XCodeBuilder extends Builder {
     public final String sdk;
     public final String xcodeProjectPath;
     public final String xcodeProjectFile;
+    public final String xcodeSchema;
+    public final String xcodeWorkspaceFile;
     public final String embeddedProfileFile;
     public final String cfBundleVersionValue;
     public final String cfBundleShortVersionStringValue;
@@ -69,7 +71,7 @@ public class XCodeBuilder extends Builder {
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd) {
+    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodeWorkspaceFile, String xcodeSchema, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd) {
         this.buildIpa = buildIpa;
         this.sdk = sdk;
         this.target = target;
@@ -77,6 +79,8 @@ public class XCodeBuilder extends Builder {
         this.configuration = configuration;
         this.xcodeProjectPath = xcodeProjectPath;
         this.xcodeProjectFile = xcodeProjectFile;
+        this.xcodeWorkspaceFile = xcodeWorkspaceFile;
+        this.xcodeSchema = xcodeSchema;
         this.embeddedProfileFile = embeddedProfileFile;
         this.cfBundleVersionValue = cfBundleVersionValue;
         this.cfBundleShortVersionStringValue = cfBundleShortVersionStringValue;
@@ -211,7 +215,13 @@ public class XCodeBuilder extends Builder {
         StringBuilder xcodeReport = new StringBuilder(Messages.XCodeBuilder_invokeXcodebuild());
         XCodeBuildOutputParser reportGenerator = new XCodeBuildOutputParser(projectRoot, listener);
         List<String> commandLine = Lists.newArrayList(getDescriptor().getXcodebuildPath());
-        if (StringUtils.isEmpty(target)) {
+
+        // Priritizing schemaa over target setting
+        if(!StringUtils.isEmpty(xcodeSchema)) {
+            commandLine.add("-scheme");
+            commandLine.add(xcodeSchema);
+            xcodeReport.append(", scheme: ").append(xcodeSchema);
+        } else if (StringUtils.isEmpty(target)) {
             commandLine.add("-alltargets");
             xcodeReport.append("target: ALL");
         } else {
@@ -228,7 +238,12 @@ public class XCodeBuilder extends Builder {
             xcodeReport.append(", sdk: DEFAULT");
         }
 
-        if (!StringUtils.isEmpty(xcodeProjectFile)) {
+        // Prioritizing workspace over project setting
+        if (!StringUtils.isEmpty(xcodeWorkspaceFile)) {
+            commandLine.add("-workspace");
+            commandLine.add(xcodeWorkspaceFile + ".xcworkspace");
+            xcodeReport.append(", workspace: ").append(xcodeWorkspaceFile);
+        } else if (!StringUtils.isEmpty(xcodeProjectFile)) {
             commandLine.add("-project");
             commandLine.add(xcodeProjectFile);
             xcodeReport.append(", project: ").append(xcodeProjectFile);

--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -53,7 +53,17 @@
     </f:entry>
 
     <f:entry title="Xcode Project File" field="xcodeProjectFile"
-      description="Only needed if there is more than one project file in the Xcode Project Directory">
+      description="Only needed if there is more than one project file in the Xcode Project Directory.">
+        <f:textbox />
+    </f:entry>
+
+    <f:entry title="Xcode Workspace File" field="xcodeWorkspaceFile"
+      description="Only needed if you want to compile a workspace instead of a project. It takes precedence over 'Xcode Project File' setting.">
+        <f:textbox />
+    </f:entry>
+
+    <f:entry title="Xcode Schema File" field="xcodeSchema"
+      description="Only needed if you want to compile for a specific schema instead of a target. It takes precedence over 'Xcode Configuration' setting.">
         <f:textbox />
     </f:entry>
 


### PR DESCRIPTION
The plugin now supports two extra configuration parameters: xcodeScheme
and xcodeWorkspaceFile.
The scheme maps to xcodebuild's parameter "-scheme"
and the workspace to "-workspace".
The scheme takes precedence over the target setting and the workspace
takes precedence over the project setting.
