### PR TITLE
Backslash escape spaces in the 'Custom xcodebuild arguments' field.

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -404,8 +404,9 @@ public class XCodeBuilder extends Builder {
 
         // Additional (custom) xcodebuild arguments
         if (!StringUtils.isEmpty(xcodebuildArguments)) {
-            String[] parts = xcodebuildArguments.split("[ ]");
+            String[] parts = xcodebuildArguments.split("(?<!\\\\)\\s+");
             for (String arg : parts) {
+		arg = arg.replaceAll("\\\\ ", " ");
                 commandLine.add(arg);
             }
         }


### PR DESCRIPTION
Allow to escape spaces in 'Custom xcodebuild arguments' field.

ex:   CODE_SIGN_IDENTITY=iPhone\ Developer:\ Todd\ Kirby
