### PR TITLE
Use junk paths flag when zipping up dSYM. Fixes JENKINS-13361.

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -472,7 +472,7 @@ public class XCodeBuilder extends Builder {
                 }
 
                 // also zip up the symbols, if present
-                returnCode = launcher.launch().envs(envs).stdout(listener).pwd(buildDirectory).cmds("zip", "-r", "-T", "-y", baseName + "-dSYM.zip", app.absolutize().getRemote() + ".dSYM").join();
+                returnCode = launcher.launch().envs(envs).stdout(listener).pwd(buildDirectory).cmds("zip", "-r", "-T", "-y", "-j", baseName + "-dSYM.zip", app.absolutize().getRemote() + ".dSYM").join();
                 if (returnCode > 0) {
                     listener.getLogger().println(Messages.XCodeBuilder_zipFailed(baseName));
                     continue;


### PR DESCRIPTION
As stated in the title, this fixes [JENKINS-13361](https://issues.jenkins-ci.org/browse/JENKINS-13361).
