### PR TITLE
Archive .dSYM with "ditto" instead of "zip"

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -472,7 +472,7 @@ public class XCodeBuilder extends Builder {
                 }
 
                 // also zip up the symbols, if present
-                returnCode = launcher.launch().envs(envs).stdout(listener).pwd(buildDirectory).cmds("zip", "-r", "-T", "-y", baseName + "-dSYM.zip", app.absolutize().getRemote() + ".dSYM").join();
+                returnCode = launcher.launch().envs(envs).stdout(listener).pwd(buildDirectory).cmds("ditto", "-c", "-k", "--keepParent", "-rsrc", baseName + "-dSYM.zip", app.absolutize().getRemote() + ".dSYM").join();
                 if (returnCode > 0) {
                     listener.getLogger().println(Messages.XCodeBuilder_zipFailed(baseName));
                     continue;


### PR DESCRIPTION
The existing "zip" command ends up embedding the full filesystem hierarchy in the zip file.
Switching to using "ditto" in this avoids the unnecessary nested folders (and preserves resource forks!).
Fixes https://issues.jenkins-ci.org/browse/JENKINS-13361
