### PR TITLE
Added option for naming *.ipa and *dSym.zip files same as Target.

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -133,11 +133,16 @@ public class XCodeBuilder extends Builder {
      * @since 1.3.2
      */
     public final String codeSigningIdentity;
+    /**
+     * @since 1.3.3
+     */
+    public final Boolean ipaNameSameAsTarget;
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean cleanTestReports, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity) {
+    public XCodeBuilder(Boolean buildIpa, Boolean ipaNameSameAsTarget, Boolean cleanBeforeBuild, Boolean cleanTestReports, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity) {
         this.buildIpa = buildIpa;
+        this.ipaNameSameAsTarget = ipaNameSameAsTarget;
         this.sdk = sdk;
         this.target = target;
         this.cleanBeforeBuild = cleanBeforeBuild;
@@ -439,9 +444,16 @@ public class XCodeBuilder extends Builder {
                     version = cfBundleShortVersionString;
                 else
                     version = cfBundleVersion;
-
-                String baseName = app.getBaseName().replaceAll(" ", "_") + "-" +
+                
+                String baseName;
+                if (ipaNameSameAsTarget) {
+                    baseName = app.getBaseName().replaceAll(" ", "_");
+                }
+                else{
+                    baseName = app.getBaseName().replaceAll(" ", "_") + "-" +
                         configuration.replaceAll(" ", "_") + (StringUtils.isEmpty(version) ? "" : "-" + version);
+                }
+                
 
                 FilePath ipaLocation = buildDirectory.child(baseName + ".ipa");
 

--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -103,6 +103,11 @@
       description="Checking this option will create a .ipa for each .app found in the build directory.">
         <f:checkbox />
     </f:entry>
+    
+    <f:entry title="${%IPA Name same as target?}" field="ipaNameSameAsTarget"
+      description="Checking this option will name .ipa same as target name. For example if you want to use a TestFlight plugin.">
+        <f:checkbox />
+    </f:entry>
 
     <f:entry title="${%Code Signing Identity}" field="codeSigningIdentity"
       description="Override the code signing identity specified in the project">

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-ipaNameSameAsTarget.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-ipaNameSameAsTarget.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2011 Ray Yamamoto Hilton
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+  <p>This option will allow you to give .ipa and -dSym.zip files same name as target</p>
+</div>


### PR DESCRIPTION
Added option for naming *.ipa and *dSym.zip files same as Target. This
is usefull if you want to upload results of build to TestFlight using
TestFlight plugin.
