### PR TITLE
Added the xcode embedded profile code signing fix identified here:https://issu...

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -464,6 +464,10 @@ public class XCodeBuilder extends Builder {
                     packageCommandLine.add("--embed");
                     packageCommandLine.add(embeddedProfileFile);
                 }
+                if (!StringUtils.isEmpty(codeSigningIdentity)) {                   
+                    packageCommandLine.add("--sign");
+                    packageCommandLine.add(codeSigningIdentity);
+                }
 
                 returnCode = launcher.launch().envs(envs).stdout(listener).pwd(projectRoot).cmds(packageCommandLine).join();
                 if (returnCode > 0) {


### PR DESCRIPTION
This adds a "Code Signing Identify" field right before the "Embedded Profile" field which allows you to specify your signing identity, and successfully embed a provisioning profile into your .IPA file.  I use it on 5 iPad apps and it works.
