### PR TITLE
Support for xcodebuild buildaction parameter customization

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -135,9 +135,14 @@ public class XCodeBuilder extends Builder {
      */
     public final String codeSigningIdentity;
 
+    /**
+     * @since 1.x
+     */
+    public final String xcodebuildAction;
+
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean cleanTestReports, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity) {
+    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean cleanTestReports, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity, String xcodebuildAction) {
         this.buildIpa = buildIpa;
         this.sdk = sdk;
         this.target = target;
@@ -158,6 +163,12 @@ public class XCodeBuilder extends Builder {
         this.keychainPwd = keychainPwd;
         this.symRoot = symRoot;
         this.configurationBuildDir = configurationBuildDir;
+        if(null == xcodebuildAction){
+            this.xcodebuildAction = "build";
+        }
+        else{
+            this.xcodebuildAction = xcodebuildAction;
+        }
     }
 
     @Override
@@ -410,6 +421,7 @@ public class XCodeBuilder extends Builder {
         } else {
             xcodeReport.append(", sdk: DEFAULT");
         }
+        xcodeReport.append(". xcodebuildAction: ").append(this.xcodebuildAction);
 
         // Prioritizing workspace over project setting
         if (!StringUtils.isEmpty(xcodeWorkspaceFile)) {
@@ -434,7 +446,9 @@ public class XCodeBuilder extends Builder {
         } else {
             xcodeReport.append(", clean: NO");
         }
-        commandLine.add("build");
+        
+        commandLine.add(this.xcodebuildAction);
+        
 
         if (!StringUtils.isEmpty(symRootValue)) {
             commandLine.add("SYMROOT=" + symRootValue);

--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -39,8 +39,8 @@
         <f:textbox/>
     </f:entry>
 
-    <f:entry title="${%Xcode Schema File}" field="xcodeSchema"
-      description="Only needed if you want to compile for a specific schema instead of a target.">
+    <f:entry title="${%Xcode Scheme}" field="xcodeSchema"
+      description="Only needed if you want to compile a scheme instead of a target.">
         <f:textbox />
     </f:entry>
 
@@ -55,7 +55,7 @@
     </f:entry>
 
     <f:entry title="${%Configuration}" field="configuration"
-      description="This is the name of the configuration as defined in the XCode project.">
+      description="This is the name of the configuration as defined in the Xcode project.">
         <f:textbox default="Release"/>
     </f:entry>
 
@@ -97,6 +97,15 @@
     <f:entry title="${%Clean test reports?}" field="cleanTestReports"
       help="/plugin/xcode/help-cleanTestReports.html">
         <f:checkbox name="xcode.cleanTestReports" checked="${instance.cleanTestReports}" />
+    </f:entry>
+
+    <f:entry title="${%xcodebuild action?}" help="/plugin/xcode/help-action.html">
+        <select name="xcodebuildAction">
+            <f:option value="build" selected="${instance.xcodebuildAction=='build'}">build</f:option>
+            <f:option value="archive" selected="${instance.xcodebuildAction=='archive'}">archive</f:option>
+            <f:option value="test" selected="${instance.xcodebuildAction=='test'}">test</f:option>
+            <f:option value="clean" selected="${instance.xcodebuildAction=='clean'}">clean</f:option>
+        </select>
     </f:entry>
 
     <f:entry title="${%Build IPA?}" field="buildIpa"

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-action.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-action.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Select which xcodebuild action to run.
+    </p>
+</div>

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-xcodeSchema.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-xcodeSchema.html
@@ -23,6 +23,6 @@
   -->
 
 <div>
-    <p>Only needed if you want to compile for a specific schema instead of a target.
+    <p>Only needed if you want to compile for a scheme instead of a target.
         It takes precedence over 'Xcode Configuration' setting and this job 'target' parameter.</p>
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -28,5 +28,5 @@
   Since we don't really have anything dynamic here, let's just use static HTML. 
 -->
 <div>
-  This plugin provides builders to build xcode projects, invoke agvtool and package .ipa files
+  This plugin provides builders to build Xcode projects, invoke agvtool and package .ipa files
 </div>


### PR DESCRIPTION
Extended the XcodeBuilder class to support overriding the buildaction passed to xcodebuild. The following buildactions are documented in the xcodebuild manpage:

build
archive
test
installsrc
install
clean

This change exposes the following commonly used buildactions:

build
archive
test
clean

Also fixed a few nitpicky capitalization and terminology errors.
