### PR TITLE
Possibility to enter Provisioning Profile Name and field for custom Artifact-Name Suffix

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -134,10 +134,14 @@ public class XCodeBuilder extends Builder {
      * @since 1.3.2
      */
     public final String codeSigningIdentity;
+    /**
+     * @since 1.3.2.x
+     */
+    public final String mobileProvisioningId;
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean cleanTestReports, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity) {
+    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean cleanTestReports, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity, String mobileProvisioningId) {
         this.buildIpa = buildIpa;
         this.sdk = sdk;
         this.target = target;
@@ -151,6 +155,7 @@ public class XCodeBuilder extends Builder {
         this.xcodeSchema = xcodeSchema;
         this.embeddedProfileFile = embeddedProfileFile;
         this.codeSigningIdentity = codeSigningIdentity;
+        this.mobileProvisioningId = mobileProvisioningId;
         this.cfBundleVersionValue = cfBundleVersionValue;
         this.cfBundleShortVersionStringValue = cfBundleShortVersionStringValue;
         this.unlockKeychain = unlockKeychain;
@@ -193,6 +198,7 @@ public class XCodeBuilder extends Builder {
         String keychainPath = envs.expand(this.keychainPath);
         String keychainPwd = envs.expand(this.keychainPwd);
         String codeSigningIdentity = envs.expand(this.codeSigningIdentity);
+        String mobileProvisioningId = envs.expand(this.mobileProvisioningId);
         // End expanding all string variables in parameters  
 
         // Set the working directory
@@ -457,6 +463,13 @@ public class XCodeBuilder extends Builder {
             xcodeReport.append(", codeSignIdentity: ").append(codeSigningIdentity);
         } else {
             xcodeReport.append(", codeSignIdentity: DEFAULT");
+        }
+        // append mobile provisioning file
+        if (!StringUtils.isEmpty(mobileProvisioningId)) {
+            commandLine.add("PROVISIONING_PROFILE=" + mobileProvisioningId);
+            xcodeReport.append(", provisioningProfile: ").append(mobileProvisioningId);
+        } else {
+            xcodeReport.append(", provisioningProfile: DEFAULT");
         }
 
         // Additional (custom) xcodebuild arguments

--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -141,11 +141,11 @@ public class XCodeBuilder extends Builder {
     /**
      * @since 1.3.2.x
      */
-    public final Boolean nightlyBuild;
+    public final String customBuildSuffix;
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean cleanTestReports, Boolean nightlyBuild, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity, String mobileProvisioningId) {
+    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean cleanTestReports, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity, String mobileProvisioningId, String customBuildSuffix) {
         this.buildIpa = buildIpa;
         this.sdk = sdk;
         this.target = target;
@@ -167,7 +167,7 @@ public class XCodeBuilder extends Builder {
         this.keychainPwd = keychainPwd;
         this.symRoot = symRoot;
         this.configurationBuildDir = configurationBuildDir;
-        this.nightlyBuild = nightlyBuild;
+        this.customBuildSuffix = customBuildSuffix;
     }
 
     @Override
@@ -204,6 +204,7 @@ public class XCodeBuilder extends Builder {
         String keychainPwd = envs.expand(this.keychainPwd);
         String codeSigningIdentity = envs.expand(this.codeSigningIdentity);
         String mobileProvisioningId = envs.expand(this.mobileProvisioningId);
+        String customBuildSuffix = envs.expand(this.customBuildSuffix);
         // End expanding all string variables in parameters  
 
         // Set the working directory
@@ -522,8 +523,8 @@ public class XCodeBuilder extends Builder {
                 else
                     version = cfBundleVersion;
 
-                if(nightlyBuild) {
-                    version = "Nightly";
+                if(customBuildSuffix.length() > 0) {
+                    version = customBuildSuffix;
                 }
 
                 String baseName = app.getBaseName().replaceAll(" ", "_") + "-" +

--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -138,10 +138,14 @@ public class XCodeBuilder extends Builder {
      * @since 1.3.2.x
      */
     public final String mobileProvisioningId;
+    /**
+     * @since 1.3.2.x
+     */
+    public final Boolean nightlyBuild;
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean cleanTestReports, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity, String mobileProvisioningId) {
+    public XCodeBuilder(Boolean buildIpa, Boolean cleanBeforeBuild, Boolean cleanTestReports, Boolean nightlyBuild, String configuration, String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments, String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile, String xcodeSchema, String configurationBuildDir, String codeSigningIdentity, String mobileProvisioningId) {
         this.buildIpa = buildIpa;
         this.sdk = sdk;
         this.target = target;
@@ -163,6 +167,7 @@ public class XCodeBuilder extends Builder {
         this.keychainPwd = keychainPwd;
         this.symRoot = symRoot;
         this.configurationBuildDir = configurationBuildDir;
+        this.nightlyBuild = nightlyBuild;
     }
 
     @Override
@@ -516,6 +521,10 @@ public class XCodeBuilder extends Builder {
                     version = cfBundleShortVersionString;
                 else
                     version = cfBundleVersion;
+
+                if(nightlyBuild) {
+                    version = "Nightly";
+                }
 
                 String baseName = app.getBaseName().replaceAll(" ", "_") + "-" +
                         configuration.replaceAll(" ", "_") + (StringUtils.isEmpty(version) ? "" : "-" + version);

--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -109,6 +109,11 @@
         <f:textbox />
     </f:entry>
 
+    <f:entry title="${%Provisioning Profile}" field="mobileProvisioningId"
+      description="Override the provisioning profile specified in the project">
+        <f:textbox />
+    </f:entry>
+
     <f:entry title="${%Embedded Profile}" field="embeddedProfileFile"
       description="The relative path to the mobileprovision to embed, leave blank for no embedded profile">
         <f:textbox />

--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -94,9 +94,9 @@
         <f:textbox />
     </f:entry>
 
-    <f:entry title="${%Nightly Build?}" field="nightlyBuild"
-      description="If checked, Version number in Artifact will be replaces by 'Nightly'.">
-        <f:checkbox />
+    <f:entry title="${%Custom Suffix}" field="customBuildSuffix"
+      description="Suffix to be used instead of Version number on Build Artifacts, leave blank for no custom suffix">
+        <f:textbox />
     </f:entry>
 
     <f:entry title="${%Clean test reports?}" field="cleanTestReports"

--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -94,6 +94,11 @@
         <f:textbox />
     </f:entry>
 
+    <f:entry title="${%Nightly Build?}" field="nightlyBuild"
+      description="If checked, Version number in Artifact will be replaces by 'Nightly'.">
+        <f:checkbox />
+    </f:entry>
+
     <f:entry title="${%Clean test reports?}" field="cleanTestReports"
       help="/plugin/xcode/help-cleanTestReports.html">
         <f:checkbox name="xcode.cleanTestReports" checked="${instance.cleanTestReports}" />


### PR DESCRIPTION
Used to override Provisioning Profile selected in Xcode Project. The commandline argument PROVISIONING_PROFILE= is used for this.

Additionally an optional Textfield to enter a custom Artifact Filename Suffix (replacing the Version number) is implemented
