### PR TITLE
Fix for global settings not reloading

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -573,6 +573,10 @@ public class XCodeBuilder extends Builder {
         private String agvtoolPath = "/usr/bin/agvtool";
         private String xcrunPath = "/usr/bin/xcrun";
 
+        public DescriptorImpl() {
+            load();
+        }
+
         public FormValidation doCheckXcodebuildPath(@QueryParameter String value) throws IOException, ServletException {
             if (StringUtils.isEmpty(value)) {
                 return FormValidation.error(Messages.XCodeBuilder_xcodebuildPathNotSet());


### PR DESCRIPTION
When Jenkins restarts, global Jenkins settings for Xcode went back to their defaults. Now when constructing the DescriptorImpl, call the load() method which will load the settings and fix the issue.
