### PR TITLE
Don't specify an empty -configuration parameter to xcodebuild

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -442,9 +442,11 @@ public class XCodeBuilder extends Builder {
             xcodeReport.append(", project: DEFAULT");
         }
 
-        commandLine.add("-configuration");
-        commandLine.add(configuration);
-        xcodeReport.append(", configuration: ").append(configuration);
+		if (!StringUtils.isEmpty(configuration)) {
+			commandLine.add("-configuration");
+			commandLine.add(configuration);
+			xcodeReport.append(", configuration: ").append(configuration);
+		}
 
         if (cleanBeforeBuild) {
             commandLine.add("clean");


### PR DESCRIPTION
If building with a scheme, not specifying a configuration would still
add the `-configuration` parameter, but the build log would show that
the default configuration was being used (n.b. NOT the configuration
specified in the scheme)

Without fix:

```
Going to invoke xcodebuild:, scheme: Testing, sdk: DEFAULT, workspace: Project.xcodeproj/project, configuration: , clean: NO, symRoot: DEFAULT, configurationBuildDir: Build
[Platform-iOS] $ /usr/bin/xcodebuild -scheme Testing -workspace Project.xcodeproj/project.xcworkspace -configuration  build CONFIGURATION_BUILD_DIR=Build
Build settings from command line:
    CONFIGURATION_BUILD_DIR = Build

=== BUILD AGGREGATE TARGET Git OF PROJECT Project WITH THE DEFAULT CONFIGURATION (Optimized) ===
```

With fix:

```
Going to invoke xcodebuild:, scheme: Testing, sdk: DEFAULT, workspace: Project.xcodeproj/project, clean: NO, symRoot: DEFAULT, configurationBuildDir: Build, codeSignIdentity: DEFAULT
[Platform-iOS] $ /usr/bin/xcodebuild -scheme Testing -workspace Project.xcodeproj/project.xcworkspace build CONFIGURATION_BUILD_DIR=Build
Build settings from command line:
    CONFIGURATION_BUILD_DIR = Build

=== BUILD AGGREGATE TARGET Git OF PROJECT Project WITH CONFIGURATION Optimized ===
```
