### PR TITLE
Adding the possibility to provide a pattern for the .ipa file name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
       <artifactId>token-macro</artifactId>
       <version>1.5.1</version>
     </dependency>
-    <dependency>
-      <groupId>com.googlecode.plist</groupId>
-	  <artifactId>dd-plist</artifactId>
-      <version>1.0</version> <!-- corresponds to r73 -->
-    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Further I extracted the marketing and technical version to its own section. Don't worry, the german localization hasn't been pushed. I'll translate the rest and do a separate pull request.

As suggested I used the EnvVars for the ${BASE_NAME}, ${VERSION}, ${SHORT_VERSION}  and ${BUILD_DATE} variables.

This extends this https://github.com/jenkinsci/xcode-plugin/pull/29 pull request.
