### PR TITLE
Fix for issue JENKINS-20037

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
+++ b/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
@@ -141,13 +141,13 @@ public class XCodeBuildOutputParser {
 
     protected void handleLine(String line) throws ParseException, IOException, InterruptedException, JAXBException {
         Matcher m = START_SUITE.matcher(line);
-        if(m.find()) {
+        if(m.matches()) {
             currentTestSuite = new TestSuite(InetAddress.getLocalHost().getHostName(), m.group(1), dateFormat.parse(m.group(2)));
             return;
         }
 
         m = END_SUITE.matcher(line);
-        if(m.find()) {
+        if(m.matches()) {
             if(currentTestSuite==null) return; // if there is no current suite, do nothing
 
             currentTestSuite.setEndTime(dateFormat.parse(m.group(2)));
@@ -158,13 +158,13 @@ public class XCodeBuildOutputParser {
         }
 
         m = START_TESTCASE.matcher(line);
-        if(m.find()) {
+        if(m.matches()) {
             currentTestCase = new TestCase(currentTestSuite.getName(), m.group(1));
             return;
         }
 
         m = END_TESTCASE.matcher(line);
-        if(m.find()) {
+        if(m.matches()) {
             requireTestSuite();
             requireTestCase(m.group(1));
 
@@ -176,7 +176,7 @@ public class XCodeBuildOutputParser {
         }
 
         m = ERROR_TESTCASE.matcher(line);
-        if(m.find()) {
+        if(m.matches()) {
 
             String errorLocation = m.group(1);
             String testSuite = m.group(2);
@@ -192,7 +192,7 @@ public class XCodeBuildOutputParser {
         }
 
         m = FAILED_TESTCASE.matcher(line);
-        if(m.find()) {
+        if(m.matches()) {
             requireTestSuite();
             requireTestCase(m.group(1));
             currentTestSuite.addTest();
@@ -204,12 +204,12 @@ public class XCodeBuildOutputParser {
         }
 
         m = FAILED_WITH_EXIT_CODE.matcher(line);
-        if(m.find()) {
+        if(m.matches()) {
             exitCode = Integer.valueOf(m.group(1));
             return;
         }
 
-        if(line.contains("BUILD FAILED")) {
+        if(line.matches("BUILD FAILED")) {
             exitCode = -1;
         }
     }


### PR DESCRIPTION
 https://issues.jenkins-ci.org/browse/JENKINS-20037

A performance regression was introduced by 46f1770 which cause a reduction in performance by an order of magnitude (4 min builds taking 40 min).

This pull reverts that change and brings build back to previous performance levels.  

46f1770 should be re-examined to find a better way of accomplishing its goal without such a drastic impact on performance of the plugin.
