### PR TITLE
Ability to add buildaction in response to https://issues.jenkins-ci.org/browse/JENKINS-20577

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <relativePath />
   </parent>
   <artifactId>xcode-plugin</artifactId>
-  <version>1.4.2-SNAPSHOT</version>
+  <version>1.4.11</version>
   <packaging>hpi</packaging>
   <name>Xcode integration</name>
   <description>This plugin adds the ability to call Xcode command line tools to automate build and packaging iOS applications (iPhone, iPad, ...).</description>

--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -159,6 +159,10 @@ public class XCodeBuilder extends Builder {
      * @since 1.4
      */
     public final Boolean provideApplicationVersion;
+    /**
+     * @since 1.4.11
+     */
+    public final String buildAction;
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
@@ -167,7 +171,7 @@ public class XCodeBuilder extends Builder {
     		String embeddedProfileFile, String cfBundleVersionValue, String cfBundleShortVersionStringValue, Boolean unlockKeychain,
     		String keychainName, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile,
     		String xcodeSchema, String configurationBuildDir, String codeSigningIdentity, Boolean allowFailingBuildResults,
-    		String ipaName, Boolean provideApplicationVersion, String ipaOutputDirectory) {
+    		String ipaName, Boolean provideApplicationVersion, String ipaOutputDirectory, String buildAction) {
         this.buildIpa = buildIpa;
         this.generateArchive = generateArchive;
         this.sdk = sdk;
@@ -194,6 +198,7 @@ public class XCodeBuilder extends Builder {
         this.ipaName = ipaName;
         this.ipaOutputDirectory = ipaOutputDirectory;
         this.provideApplicationVersion = provideApplicationVersion;
+        this.buildAction = buildAction;
     }
 
     @Override
@@ -229,6 +234,7 @@ public class XCodeBuilder extends Builder {
         String codeSigningIdentity = envs.expand(this.codeSigningIdentity);
         String ipaName = envs.expand(this.ipaName);
         String ipaOutputDirectory = envs.expand(this.ipaOutputDirectory);
+        String buildAction = envs.expand(this.buildAction);
         // End expanding all string variables in parameters  
 
         // Set the working directory
@@ -484,7 +490,14 @@ public class XCodeBuilder extends Builder {
         } else {
             xcodeReport.append(", clean: NO");
         }
-        commandLine.add("build");
+
+        //commandLine.add("build");
+        //sample buildActions include build | test
+        if( buildAction == null || buildAction.trim().equals("") ){
+            commandLine.add("build");
+        }else {
+            commandLine.add(buildAction);
+        }
         
         if(generateArchive){
             commandLine.add("archive");

--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -143,6 +143,11 @@
 		      description="Only needed if you want to compile for a specific schema instead of a target.">
 		        <f:textbox />
 		    </f:entry>
+
+		    <f:entry title="BuildAction" field="buildAction"
+                description="Leave empty for default buildAction = build">
+              <f:textbox/>
+            </f:entry>
 		
 		    <f:entry title="${%SDK}" field="sdk"
 		      description="Leave empty for default SDK">

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-buildAction.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-buildAction.html
@@ -1,0 +1,35 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2011 Ray Yamamoto Hilton
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    <p>
+        You only need to supply this value if you want to specify the SYMROOT path to use.<br/>
+        If empty, the default SYMROOT path will be used (it could be different depending of your Xcode version).<br/>
+        Supports all macros and also environment and <a href="http://ci.jenkins-ci.org/env-vars.html" target="_blank">build
+        variables</a> from the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Token+Macro+Plugin" target="_blank">Token
+        Macro Plugin</a>.<br/>
+        For example you can use the value : <br/>
+    </p>
+    <pre>${WORKSPACE}/symroot</pre>
+</div>

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-buildAction.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-buildAction.html
@@ -24,12 +24,7 @@
 
 <div>
     <p>
-        You only need to supply this value if you want to specify the SYMROOT path to use.<br/>
-        If empty, the default SYMROOT path will be used (it could be different depending of your Xcode version).<br/>
-        Supports all macros and also environment and <a href="http://ci.jenkins-ci.org/env-vars.html" target="_blank">build
-        variables</a> from the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Token+Macro+Plugin" target="_blank">Token
-        Macro Plugin</a>.<br/>
-        For example you can use the value : <br/>
+        You only need to supply this value if you want to specify the buildaction to perform.<br/>
+        Valid values include: build | analyze | archive | test | installsrc | install | clean . More info <a href="https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcodebuild.1.html" target="_blank">here</a>
     </p>
-    <pre>${WORKSPACE}/symroot</pre>
 </div>


### PR DESCRIPTION
This allows a user to enter a specific buildaction like test or analyze . The JIRA is here: https://issues.jenkins-ci.org/browse/JENKINS-20577

Previously, the only buildaction supported was to build.  This change allows a user to specify a different buildaction like "test".  The various build actions are specified by Apple here: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcodebuild.1.html

![screen shot 2013-11-14 at 2 54 41 pm](https://f.cloud.github.com/assets/376307/1546100/e4b2ed0a-4d7f-11e3-8b70-ec3371265055.png)
