### PR TITLE
Fix NullPointerException with old configs

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -572,7 +572,7 @@ public class XCodeBuilder extends Builder {
                 String version = "";
                 String shortVersion = "";
                 
-                if (!provideApplicationVersion) {
+                if (provideApplicationVersion == null || !provideApplicationVersion) {
 	                try {
 	                	output.reset();
 	                    returnCode = launcher.launch().envs(envs).cmds("/usr/libexec/PlistBuddy", "-c",  "Print :CFBundleVersion", app.absolutize().child("Info.plist").getRemote()).stdout(output).pwd(projectRoot).join();


### PR DESCRIPTION
Fixes errors like this:

```
java.lang.NullPointerException
    at au.com.rayh.XCodeBuilder.perform(XCodeBuilder.java:575)
    at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
    at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:781)
    at hudson.model.Build$BuildExecution.build(Build.java:199)
    at hudson.model.Build$BuildExecution.doRun(Build.java:160)
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:562)
    at hudson.model.Run.execute(Run.java:1665)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:46)
    at hudson.model.ResourceController.execute(ResourceController.java:88)
    at hudson.model.Executor.run(Executor.java:246)
```
