### PR TITLE
JENKINS-19595: Support multiple targets to be passed into xcodebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ work
 .idea
 test-*
 *.iml
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ work
 test-*
 *.iml
 .DS_Store
+*.orig

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <relativePath />
   </parent>
   <artifactId>xcode-plugin</artifactId>
-  <version>1.4.7-SNAPSHOT</version>
+  <version>1.4.6~volvo1</version>
   <packaging>hpi</packaging>
   <name>Xcode integration</name>
   <description>This plugin adds the ability to call Xcode command line tools to automate build and packaging iOS applications (iPhone, iPad, ...).</description>

--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -24,6 +24,8 @@
 
 package au.com.rayh;
 
+import com.google.common.base.Predicates;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -50,7 +52,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Pattern;
+import java.util.Collection;
 
 /**
  * @author Ray Hilton
@@ -501,19 +503,18 @@ public class XCodeBuilder extends Builder {
                 listener.getLogger().println(Messages.XCodeBuilder_NoTargetsFoundInConfig());
                 return false;
             }
-            Boolean matchFound = Boolean.FALSE;
-            Pattern p = Pattern.compile(target);
-            for (String availableTarget : xcodebuildListParser.getTargets()) {
-                if(p.matcher(availableTarget).matches()) {
-                    commandLine.add("-target");
-                    commandLine.add(availableTarget);
-                    xcodeReport.append("target: ").append(availableTarget);
-                    matchFound = Boolean.TRUE;
-                }
-            }
-            if(!matchFound) {
+            Collection<String> matchedTargets = Collections2.filter(xcodebuildListParser.getTargets(),
+                    Predicates.containsPattern(target));
+
+            if (matchedTargets.isEmpty()) {
                 listener.getLogger().println(Messages.XCodeBuilder_NoMatchingTargetsFound());
                 return false;
+            }
+
+            for (String matchedTarget : matchedTargets) {
+                commandLine.add("-target");
+                commandLine.add(matchedTarget);
+                xcodeReport.append("target: ").append(matchedTarget);
             }
         } else {
             commandLine.add("-target");

--- a/src/main/java/au/com/rayh/XcodeBuildListParser.java
+++ b/src/main/java/au/com/rayh/XcodeBuildListParser.java
@@ -15,6 +15,11 @@ public class XcodeBuildListParser {
     private List<String> schemes = new ArrayList<String>();
 
     public XcodeBuildListParser(String xcodebuildListOutput) {
+
+        if(xcodebuildListOutput == null) {
+            return;
+        }
+
         String [] lines = xcodebuildListOutput.split("\n");
         List<String> curList = null;
         for(String line : lines) {
@@ -23,7 +28,7 @@ public class XcodeBuildListParser {
                 curList = null;
             } else if("Targets:".equals(line)) {
                 curList = targets;
-            } else if("Build Configurations::".equals(line)) {
+            } else if("Build Configurations:".equals(line)) {
                 curList = configurations;
             } else if("Schemes:".equals(line)) {
                 curList = schemes;

--- a/src/main/java/au/com/rayh/XcodeBuildListParser.java
+++ b/src/main/java/au/com/rayh/XcodeBuildListParser.java
@@ -1,0 +1,47 @@
+package au.com.rayh;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+
+
+/**
+ * Created by ud10404 on 5/9/14.
+ */
+public class XcodeBuildListParser {
+
+    private List<String> targets = new ArrayList<String>();
+    private List<String> configurations = new ArrayList<String>();
+    private List<String> schemes = new ArrayList<String>();
+
+    public XcodeBuildListParser(String xcodebuildListOutput) {
+        String [] lines = xcodebuildListOutput.split("\n");
+        List<String> curList = null;
+        for(String line : lines) {
+            line = line.trim();
+            if (StringUtils.isEmpty(line)) {
+                curList = null;
+            } else if("Targets:".equals(line)) {
+                curList = targets;
+            } else if("Build Configurations::".equals(line)) {
+                curList = configurations;
+            } else if("Schemes:".equals(line)) {
+                curList = schemes;
+            } else if(curList != null) {
+                curList.add(line);
+            }
+        }
+    }
+
+    public List<String> getTargets() {
+        return this.targets;
+    }
+
+    public List<String> getConfigurations() {
+        return this.configurations;
+    }
+
+    public List<String> getSchemes() {
+        return this.schemes;
+    }
+}

--- a/src/main/resources/au/com/rayh/Messages.properties
+++ b/src/main/resources/au/com/rayh/Messages.properties
@@ -66,6 +66,8 @@ XCodeBuilder.xcrunPathNotSet=Please specify the path to the xcrun executable (us
 XCodeBuilder.zipFailed=Failed to zip *.dSYM into {0}-dSYM.zip
 XCodeBuilder.CFBundleIdentifierChanged=Changing CFBundleIdentifier from {0} to {1}
 XCodeBuilder.CFBundleIdentifierInfoPlistNotFound=No info.plist found: {0}
+XCodeBuilder.NoTargetsFoundInConfig=Unable to find any targets.
+XCodeBuilder.NoMatchingTargetsFound=No Targets found matching regular expression.
 
 ################################################################################
 OSXKeychainBuildWrapper.restoreOSXKeychainsAfterBuildProcessAsDefinedInGlobalConfiguration=Restore OS X keychains after build process as defined in global configuration

--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -41,7 +41,11 @@
 	      description="Leave empty for all targets">
 	        <f:textbox/>
 	    </f:entry>
-	    
+
+        <f:entry title="" field="interpretTargetAsRegEx">
+            <f:checkbox title="${%Interpret As Regular Expression}" />
+        </f:entry>
+
 		<f:advanced title="Settings">
 		    <f:entry title="${%Clean before build?}" field="cleanBeforeBuild"
 		      description="This will delete the build directories before invoking the build.">

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-intepretTargetAsRegEx.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-intepretTargetAsRegEx.html
@@ -1,0 +1,30 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2011 Ray Yamamoto Hilton
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    <p>
+        The target value will be interpret as a regular expression and compared againt the list of targes
+         found by executing xcodebuild -list
+    </p>
+</div>

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-intepretTargetAsRegEx.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-intepretTargetAsRegEx.html
@@ -24,7 +24,6 @@
 
 <div>
     <p>
-        The target value will be interpret as a regular expression and compared againt the list of targes
-         found by executing xcodebuild -list
+        Build all entries listed under the "Targets:" section of the xcodebuild -list output that match the regexp.
     </p>
 </div>

--- a/src/test/java/au/com/rayh/XCodeBuildListParserTest.java
+++ b/src/test/java/au/com/rayh/XCodeBuildListParserTest.java
@@ -1,0 +1,79 @@
+package au.com.rayh;
+
+import org.junit.Assert;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+/**
+ * Created by timothy on 9/6/14.
+ */
+public class XCodeBuildListParserTest {
+
+
+    @Test
+    public void testValidOutput() throws Throwable {
+        String xcodeBuildOutput = FileUtils.readFileToString(FileUtils.toFile(ClassLoader.getSystemResource("xcodebuildlist-valid.txt")));
+
+        XcodeBuildListParser parser = new XcodeBuildListParser(xcodeBuildOutput);
+
+        Assert.assertEquals(4, parser.getTargets().size());
+        Assert.assertEquals(2, parser.getConfigurations().size());
+        Assert.assertEquals(2, parser.getSchemes().size());
+
+        Assert.assertTrue(parser.getTargets().contains("SampleTarget1"));
+        Assert.assertTrue(parser.getTargets().contains("SampleTarget2"));
+        Assert.assertTrue(parser.getTargets().contains("TestSampleTarget1"));
+        Assert.assertTrue(parser.getTargets().contains("TestSampleTarget2"));
+        Assert.assertTrue(parser.getConfigurations().contains("BuildConfiguration1"));
+        Assert.assertTrue(parser.getConfigurations().contains("BuildConfiguration2"));
+        Assert.assertTrue(parser.getSchemes().contains("SampleScheme1"));
+        Assert.assertTrue(parser.getSchemes().contains("SampleScheme2"));
+
+    }
+
+    @Test
+    public void testInvalidOutputNull() throws Throwable {
+        XcodeBuildListParser parser = new XcodeBuildListParser(null);
+
+        Assert.assertEquals(0, parser.getTargets().size());
+        Assert.assertEquals(0, parser.getConfigurations().size());
+        Assert.assertEquals(0, parser.getSchemes().size());
+
+    }
+
+    @Test
+    public void testInvalidOutputEmpty() throws Throwable {
+        String xcodeBuildOutput = FileUtils.readFileToString(FileUtils.toFile(ClassLoader.getSystemResource("xcodebuildlist-invalid1.txt")));
+
+        XcodeBuildListParser parser = new XcodeBuildListParser("");
+
+        Assert.assertEquals(0, parser.getTargets().size());
+        Assert.assertEquals(0, parser.getConfigurations().size());
+        Assert.assertEquals(0, parser.getSchemes().size());
+
+    }
+
+    @Test
+    public void testInvalidOutputExtraLine() throws Throwable {
+        String xcodeBuildOutput = FileUtils.readFileToString(FileUtils.toFile(ClassLoader.getSystemResource("xcodebuildlist-invalid1.txt")));
+
+        XcodeBuildListParser parser = new XcodeBuildListParser(xcodeBuildOutput);
+
+        Assert.assertEquals(0, parser.getTargets().size());
+        Assert.assertEquals(0, parser.getConfigurations().size());
+        Assert.assertEquals(0, parser.getSchemes().size());
+
+    }
+
+    @Test
+    public void testInvalidOutputMissngColon() throws Throwable {
+        String xcodeBuildOutput = FileUtils.readFileToString(FileUtils.toFile(ClassLoader.getSystemResource("xcodebuildlist-invalid2.txt")));
+
+        XcodeBuildListParser parser = new XcodeBuildListParser(xcodeBuildOutput);
+
+        Assert.assertEquals(0, parser.getTargets().size());
+        Assert.assertEquals(0, parser.getConfigurations().size());
+        Assert.assertEquals(0, parser.getSchemes().size());
+
+    }
+}

--- a/src/test/resources/xcodebuildlist-invalid1.txt
+++ b/src/test/resources/xcodebuildlist-invalid1.txt
@@ -1,0 +1,19 @@
+Information about project "SampleXcodeProject":
+    Targets:
+
+        SampleTarget1
+        SampleTarget2
+        TestSampleTarget1
+        TestSampleTarget2
+
+    Build Configurations:
+
+        BuildConfiguration1
+        BuildConfiguration2
+
+    If no build configuration is specified and -scheme is not passed then "Release" is used.
+
+    Schemes:
+
+        SampleScheme1
+        SampleScheme2

--- a/src/test/resources/xcodebuildlist-invalid2.txt
+++ b/src/test/resources/xcodebuildlist-invalid2.txt
@@ -1,0 +1,16 @@
+Information about project "SampleXcodeProject":
+    Targets
+        SampleTarget1
+        SampleTarget2
+        TestSampleTarget1
+        TestSampleTarget2
+
+    Build Configurations
+        BuildConfiguration1
+        BuildConfiguration2
+
+    If no build configuration is specified and -scheme is not passed then "Release" is used.
+
+    Schemes
+        SampleScheme1
+        SampleScheme2

--- a/src/test/resources/xcodebuildlist-valid.txt
+++ b/src/test/resources/xcodebuildlist-valid.txt
@@ -1,0 +1,16 @@
+Information about project "SampleXcodeProject":
+    Targets:
+        SampleTarget1
+        SampleTarget2
+        TestSampleTarget1
+        TestSampleTarget2
+
+    Build Configurations:
+        BuildConfiguration1
+        BuildConfiguration2
+
+    If no build configuration is specified and -scheme is not passed then "Release" is used.
+
+    Schemes:
+        SampleScheme1
+        SampleScheme2


### PR DESCRIPTION
Added a check box to indicate the target field should be interpreted as a regular expression.  The output of the xcodebuild -list command is redirected to a byte array so it can be parsed as well as logged. When checked the parsed list of targets are compared against the regex and a -target <target> parameter is added when a match is found.  