### PR TITLE
getKeychain returns a global keychain preferred over a local path

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -695,13 +695,15 @@ public class XCodeBuilder extends Builder {
     }
 
     public Keychain getKeychain() {
+        if(!StringUtils.isEmpty(keychainName)) {
+            for (Keychain keychain : getGlobalConfiguration().getKeychains()) {
+                if(keychain.getKeychainName().equals(keychainName))
+                    return keychain;
+            }
+        }
+        
         if(!StringUtils.isEmpty(keychainPath)) {
             return new Keychain("", keychainPath, keychainPwd, false);
-        }
-
-        for (Keychain keychain : getGlobalConfiguration().getKeychains()) {
-            if(keychain.getKeychainName().equals(keychainName))
-                return keychain;
         }
 
         return null;


### PR DESCRIPTION
When both a keychainName and keychainPath are provided in the Builder this method will now return a keychain from the global keychain, before falling back to the keychainPath.

This matches the configuration UI where setting a keychainName hides the keychainPath fields but the values remain.
![Hidden keychainPath/Pwd fields](https://cloud.githubusercontent.com/assets/690052/3585475/35178894-0c27-11e4-98ed-9772f1a06df0.png)

![Visible only when keychainName is none](https://cloud.githubusercontent.com/assets/690052/3585477/39ae7c5a-0c27-11e4-9ffe-7a332268c3d6.png)
