### PR TITLE
Add Test Suite finish compatibility for Xcode 6 beta 4

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
+++ b/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
@@ -55,7 +55,7 @@ public class XCodeBuildOutputParser {
 
     private static DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
     private static Pattern START_SUITE = Pattern.compile("Test Suite '(\\S+)'.*started at\\s+(.*)");
-    private static Pattern END_SUITE = Pattern.compile("Test Suite '(\\S+)'.*finished at\\s+(.*).");
+    private static Pattern END_SUITE = Pattern.compile("Test Suite '(\\S+)'.*\\S+ at\\s+(.*).");
     private static Pattern START_TESTCASE = Pattern.compile("Test Case '-\\[\\S+\\s+(\\S+)\\]' started.");
     private static Pattern END_TESTCASE = Pattern.compile("Test Case '-\\[\\S+\\s+(\\S+)\\]' passed \\((.*) seconds\\).");
     private static Pattern ERROR_TESTCASE = Pattern.compile("(.*): error: -\\[(\\S+) (\\S+)\\] : (.*)");


### PR DESCRIPTION
[FIXED JENKINS-24120]
Compatible for Xcode 5 and Xcode 6.

Xcode 5 Log:
Test Suite 'SCTests_ResultInterpreter' started at 2014-08-01 04:09:27 +0000
...
Test Suite 'SCTests_ResultInterpreter' finished at 2014-08-01 04:09:27 +0000.
Executed 24 tests, with 0 failures (0 unexpected) in 0.024 (0.025) seconds

Xcode 6 beta 4 log:
Test Suite 'SCTests_ResultInterpreter' started at 2014-07-31 23:23:19 +0000
...
Test Suite 'SCTests_ResultInterpreter' passed at 2014-07-31 23:23:19 +0000.
     Executed 24 tests, with 0 failures (0 unexpected) in 0.031 (0.037) seconds

Notice that in Xcode 5, the test log for Test Suite is 'finished', while in Xcode 6, the log states that the suite 'passed'.
