### PR TITLE
Add xcode builder environment variables

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -32,6 +32,7 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.model.Environment;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.CopyOnWriteList;
@@ -645,6 +646,8 @@ public class XCodeBuilder extends Builder {
                 		"SHORT_VERSION", shortVersion,
                 		"BUILD_DATE", lastModified
                 	);
+                    // Add environment variables for downstream tasks
+                    build.getEnvironments().add(Environment.create(customVars));
                     baseName = customVars.expand(ipaName);
                 }
 


### PR DESCRIPTION
If a user defines a custom ipaName, then add the environment variables to the build environment, so downstream tasks are allowed to use those variables.
