### PR TITLE
Fixing dropped return code

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -679,14 +679,14 @@ public class XCodeBuilder extends Builder {
                 returnCode = launcher.launch().envs(envs).stdout(listener).pwd(projectRoot).cmds(packageCommandLine).join();
                 if (returnCode > 0) {
                     listener.getLogger().println("Failed to build " + ipaLocation.absolutize().getRemote());
-                    continue;
+                    return false;
                 }
 
                 // also zip up the symbols, if present
                 returnCode = launcher.launch().envs(envs).stdout(listener).pwd(buildDirectory).cmds("ditto", "-c", "-k", "--keepParent", "-rsrc", app.absolutize().getRemote() + ".dSYM", ipaOutputPath.child(baseName + "-dSYM.zip").absolutize().getRemote()).join();
                 if (returnCode > 0) {
                     listener.getLogger().println(Messages.XCodeBuilder_zipFailed(baseName));
-                    continue;
+                    return false;
                 }
 
                 if(!StringUtils.isEmpty(ipaManifestPlistUrl)) {


### PR DESCRIPTION
The return code from these commands wasn't failing the build overall.

When we cannot create the IPA, it seems like we ought to fail.  Future build steps may depend on the existence of the .ipa, and it seems best to fail early in a build to ease troubleshooting.
