### PR TITLE
Gave productsign same permissions as codesign to access imported keys without prompt.

### DIFF
--- a/src/main/java/au/com/rayh/DeveloperProfileLoader.java
+++ b/src/main/java/au/com/rayh/DeveloperProfileLoader.java
@@ -80,6 +80,7 @@ public class DeveloperProfileLoader extends Builder {
             args.add(id).add("-k",keyChain);
             args.add("-P").addMasked(dp.getPassword().getPlainText());
             args.add("-T","/usr/bin/codesign");
+            args.add("-T","/usr/bin/productsign");
             args.add(keyChain);
             invoke(launcher, listener, args, "Failed to import identity "+id);
         }


### PR DESCRIPTION
Using productsign as apart of a job requires user interaction if it isn't given permission using '-T' on the 'security import' command.