### PR TITLE
Adds regex for parsing UI test failures (for Xcode 8)

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
+++ b/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
@@ -64,6 +64,7 @@ public class XCodeBuildOutputParser {
     private static Pattern START_TESTCASE = Pattern.compile("Test Case '-\\[\\S+\\s+(\\S+)\\]' started.");
     private static Pattern END_TESTCASE = Pattern.compile("Test Case '-\\[\\S+\\s+(\\S+)\\]' passed \\((.*) seconds\\).");
     private static Pattern ERROR_TESTCASE = Pattern.compile("(.*): error: -\\[(\\S+) (\\S+)\\] : (.*)");
+    private static Pattern ERROR_UI_TESTCASE = Pattern.compile(".*?Assertion Failure: (.+:\\d+): (.*)");
     private static Pattern FAILED_TESTCASE = Pattern.compile("Test Case '-\\[\\S+ (\\S+)\\]' failed \\((\\S+) seconds\\).");
     private static Pattern FAILED_WITH_EXIT_CODE = Pattern.compile("failed with exit code (\\d+)");
     private static Pattern TERMINATING_EXCEPTION = Pattern.compile(".*\\*\\*\\* Terminating app due to uncaught exception '(\\S+)', reason: '(.+[^\\\\])'.*");
@@ -218,6 +219,16 @@ public class XCodeBuildOutputParser {
 
             requireTestSuite(testSuite);
             requireTestCase(testCase);
+
+            TestFailure failure = new TestFailure(errorMessage, errorLocation);
+            currentTestCase.getFailures().add(failure);
+            return;
+        }
+	
+        m = ERROR_UI_TESTCASE.matcher(line);
+        if(m.matches()) {
+            String errorLocation = m.group(1);
+            String errorMessage = m.group(2);
 
             TestFailure failure = new TestFailure(errorMessage, errorLocation);
             currentTestCase.getFailures().add(failure);

--- a/src/test/java/au/com/rayh/OutputParserTests.java
+++ b/src/test/java/au/com/rayh/OutputParserTests.java
@@ -104,6 +104,16 @@ class OutputParserTests {
         assertEquals("/Users/ray/Development/Projects/Java/xcodebuild-hudson-plugin/work/jobs/PBS Streamer/workspace/PisClientTestCase.m:21", parser.currentTestCase.getFailures().get(0).getLocation());
         assertEquals("\"((nil) != nil)\" should be true. This always fails", parser.currentTestCase.getFailures().get(0).getMessage());
     }
+	
+	void shouldAddUIErrorToTestCase() throws Exception {
+        parser.currentTestSuite = new TestSuite("host", "PisClientTestCase", new Date());
+        parser.currentTestCase = new TestCase("PisClientTestCase", "testThatFails");
+        String line = "t =    29.77s             Assertion Failure: AppUITests.m:31: UI Testing Failure - No matches found for Alert";
+        parser.handleLine(line);
+        assertEquals(1, parser.currentTestCase.getFailures().size());
+        assertEquals("AppUITests.m:31", parser.currentTestCase.getFailures().get(0).getLocation());
+        assertEquals("UI Testing Failure - No matches found for Alert", parser.currentTestCase.getFailures().get(0).getMessage());
+    }
 
 	void shouldParsePassedTestCase() throws Exception {
         parser.currentTestSuite = new TestSuite("host", "PisClientTestCase", new Date());

--- a/src/test/java/au/com/rayh/XCodeBuildOutputParserTest.java
+++ b/src/test/java/au/com/rayh/XCodeBuildOutputParserTest.java
@@ -92,6 +92,11 @@ public class XCodeBuildOutputParserTest {
     public void shouldAddErrorToTestCase() throws Exception {
     	test.shouldAddErrorToTestCase();
     }
+    
+    @Test
+    public void shouldAddUIErrorToTestCase() throws Exception {
+    	test.shouldAddUIErrorToTestCase();
+    }
 
     @Test
     public void shouldParsePassedTestCase() throws Exception {


### PR DESCRIPTION
Xcode 8 slightly changes the log output for UI test failures. Currently, the Xcode plugin will report failures in UI tests as _passes_. This adds a regex to explicitly check for UI test failures.
