### PR TITLE
When signing xcode9 Add the provisioningProfiles entry to the Plist file. To avoid the following error -fix

### DIFF
--- a/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/config.jelly
@@ -93,6 +93,19 @@
                         description="The base URL to use to create a Manifest Plist. If omitted no Manifest Plist will be generated">
                         <f:textbox />
                     </f:entry>
+                    
+                     
+                    <f:entry title="${%Sign ProvisioningProfiles Key}" field="provisioningProfilesKey"
+                        description="xcode9 used as the value of the provisioningProfiles key field when signed">
+                        <f:textbox />
+                    </f:entry>
+                    
+                    <f:entry title="${%Sign ProvisioningProfiles Value}" field="provisioningProfilesValue"
+                        description="xcode9 used as the value of the provisioningProfiles value field when signed">
+                        <f:textbox />
+                    </f:entry>
+                    
+                    
                 </f:optionalBlock>
             </f:entry>
         </f:advanced>

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-provisioningProfilesKey.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-provisioningProfilesKey.html
@@ -1,0 +1,42 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2018 Kimtaeyoon
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+  <p>
+  	
+	When signing xcode9 Add the provisioningProfiles entry to the Plist file. To avoid the following error <br>
+    Xcode9 sign error: exportArchive: "MyApp.app" requires a provisioning profile.Error Domain=IDEProvisioningErrorDomain Code=9 .<br>
+    </p><p>
+    </p><p></p>
+    <p></p>Additional plist<br>
+	&lt;key&gt;provisioningProfiles&lt;/key&gt;<br>
+	&lt;dict&gt;<br>
+	&lt;key&gt;${PROVISIONINGPROFILES_KEY&lt;/key&gt;<br>
+	&lt;string&gt;${PROVISIONINGPROFILES_VALUE}&lt;/string&gt;<br>
+	&lt;/dict&gt;<br>
+	<br>
+	&nbsp;<br>
+	<br>
+
+</div>


### PR DESCRIPTION
…ile. To avoid the following error -fix

Xcode9 sign error: exportArchive: "MyApp.app" requires a provisioning profile.Error Domain=IDEProvisioningErrorDomain Code=9 .

Related error issue URL: https://issues.jenkins-ci.org/browse/JENKINS-45509