### PR TITLE
Fix for FATAL: Log statements out of sync

### DIFF
--- a/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
+++ b/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
@@ -200,12 +200,25 @@ public class XCodeBuildOutputParser {
 
         m = END_TESTCASE.matcher(line);
         if(m.matches()) {
-            requireTestSuite();
-            requireTestCase(m.group(1));
-
-            currentTestCase.setTime(Float.valueOf(m.group(2)));
-            currentTestSuite.getTestCases().add(currentTestCase);
-            currentTestSuite.addTest();
+            
+        		String currentTestCaseName = m.group(1);
+        		TestCase localTestCase = null;
+        		
+            if(currentTestSuite == null) {
+            		currentTestSuite = new TestSuite(InetAddress.getLocalHost().getHostName(), "UnknownSuite", new Date());
+            }
+                  
+            if(currentTestCase == null) {
+            		localTestCase = new TestCase(currentTestSuite.getName(), currentTestCaseName);
+            }else {
+            		localTestCase = currentTestCase;
+            }
+            
+            localTestCase.setTime(Float.valueOf(m.group(2)));
+        		currentTestSuite.getTestCases().add(localTestCase);
+        		currentTestSuite.addTest();
+            
+            
             currentTestCase = null;
             return;
         }


### PR DESCRIPTION
Don't die if there is a success message in the log. Try to find fallback possibilities to categorise the test. (You cannot influence anyhow the order of lines in the xcode log)