### PR TITLE
Fix xcodeoutput perser

### DIFF
--- a/src/main/java/au/com/rayh/JenkinsXCodeBuildOutputParser.java
+++ b/src/main/java/au/com/rayh/JenkinsXCodeBuildOutputParser.java
@@ -66,9 +66,11 @@ public class JenkinsXCodeBuildOutputParser extends XCodeBuildOutputParser {
     }
     
     public void setLogfilePath(final FilePath buildDirectory, final String logfileOutputDirectory) throws IOException, InterruptedException {
-        if(buildDirectory.exists() && buildDirectory.isDirectory() && !StringUtils.isEmpty(logfileOutputDirectory)) {
-            final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyyMMdd_hhmmssSSS");
-            final String logfileName = dateFormatter.format(new GregorianCalendar().getTime());
+	// Remove buildDirectory.exists() && buildDirectory.isDirectory() from condition.
+	// Because If Generate archive is not specified, directory was not created.
+        if(!StringUtils.isEmpty(logfileOutputDirectory)) {
+	    // Fix not to use timestamp for log file name. (Use "xcodebuild.log" as a fixed file name)
+	    // Because using a timestamp as a filename, No way to know it with a script etc.
             FilePath logFilePath = buildDirectory.child(logfileOutputDirectory);
             // clean Directory
             if(logFilePath.exists()) {
@@ -78,7 +80,7 @@ public class JenkinsXCodeBuildOutputParser extends XCodeBuildOutputParser {
             if (!logFilePath.exists()) {
                 logFilePath.mkdirs();
             }
-            logFileOutputStream = new BufferedOutputStream(logFilePath.child(logfileName + ".log").write(),1024*512);
+            logFileOutputStream = new BufferedOutputStream(logFilePath.child("xcodebuild.log").write(),1024*512);
         }
     }
     

--- a/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
+++ b/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
@@ -34,6 +34,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -55,24 +56,25 @@ import au.com.rayh.report.TestSuite;
 
 public class XCodeBuildOutputParser {
 
-	private static DateFormat[] dateFormats = {
-		new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z"),
-		new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
-	};
-    private static Pattern START_SUITE = Pattern.compile("Test Suite '([^/].+)'.*started at\\s+(.*)");
-    private static Pattern END_SUITE = Pattern.compile("Test Suite '([^/].+)'.*\\S+ at\\s+(.*).");
-    private static Pattern START_TESTCASE = Pattern.compile("Test Case '-\\[\\S+\\s+(\\S+)\\]' started.");
-    private static Pattern END_TESTCASE = Pattern.compile("Test Case '-\\[\\S+\\s+(\\S+)\\]' passed \\((.*) seconds\\).");
-    private static Pattern ERROR_TESTCASE = Pattern.compile("(.*): error: -\\[(\\S+) (\\S+)\\] : (.*)");
+    private static DateFormat[] dateFormats = {
+	new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z"),
+	new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+    };
+    private static Pattern START_SUITE = Pattern.compile("Test Suite '([^\\/](?:\\.|[^'\\\\])*)'\\s+started at\\s+(.*)");
+    private static Pattern END_SUITE = Pattern.compile("Test Suite '([^\\/](?:\\.|[^'\\\\])*)'\\s+\\S+\\s+at\\s+(.*).");
+    private static Pattern START_TESTCASE = Pattern.compile("Test Case '-\\[(\\S+)\\s+(\\S+)\\]' started.");
+    private static Pattern END_TESTCASE = Pattern.compile("Test Case '-\\[(\\S+)\\s+(\\S+)\\]' passed \\((.*) seconds\\).");
+    private static Pattern ERROR_TESTCASE = Pattern.compile("(.*): error: -\\[(\\S+)\\s+(\\S+)\\] : (.*)");
     private static Pattern ERROR_UI_TESTCASE = Pattern.compile(".*?Assertion Failure: (.+:\\d+): (.*)");
-    private static Pattern FAILED_TESTCASE = Pattern.compile("Test Case '-\\[\\S+ (\\S+)\\]' failed \\((\\S+) seconds\\).");
+    private static Pattern FAILED_TESTCASE = Pattern.compile("Test Case '-\\[(\\S+)\\s+(\\S+)\\]' failed \\((\\S+) seconds\\).");
     private static Pattern FAILED_WITH_EXIT_CODE = Pattern.compile("failed with exit code (\\d+)");
     private static Pattern TERMINATING_EXCEPTION = Pattern.compile(".*\\*\\*\\* Terminating app due to uncaught exception '(\\S+)', reason: '(.+[^\\\\])'.*");
     private File testReportsDir;
     protected OutputStream captureOutputStream;
     protected int exitCode;
-    protected TestSuite currentTestSuite;
-    protected TestCase currentTestCase;
+    protected HashMap<String, TestSuite> testSuitesHash = new HashMap<String, TestSuite>();
+    protected TestSuite currentTestSuite = null;
+    protected TestCase currentTestCase = null;
     protected boolean consoleLog;
 
     protected XCodeBuildOutputParser() {
@@ -114,47 +116,61 @@ public class XCodeBuildOutputParser {
         }
     }
 
-	private Date parseDate(String text) throws ParseException {
-		Date date;
-		ParseException parseException;
+    private Date parseDate(String text) throws ParseException {
+	Date date;
+	ParseException parseException;
 
-		date = null;
-		parseException = null;
+	date = null;
+	parseException = null;
 
-		for (DateFormat dateFormat : dateFormats) {
-			try {
-				date = dateFormat.parse(text);
-				break;
-			} catch (ParseException exception) {
-				parseException = exception;
-			}
-		}
-
-		if ((date == null) && (parseException != null)) {
-			throw parseException;
-		}
-
-		return date;
+	for (DateFormat dateFormat : dateFormats) {
+	    try {
+		date = dateFormat.parse(text);
+		break;
+	    } catch (ParseException exception) {
+		parseException = exception;
+	    }
 	}
 
-	private void requireTestSuite() {
-        if(currentTestSuite==null) {
-            throw new RuntimeException("Log statements out of sync: current test suite was null");
-        }
+	if ((date == null) && (parseException != null)) {
+	    throw parseException;
+	}
+
+	return date;
+    }
+
+    private void requireTestSuite() {
+	if(testSuitesHash.size()==0) {
+	    throw new RuntimeException("Log statements out of sync: current test suite was empty");
+	}
+	if(currentTestSuite==null) {
+	    throw new RuntimeException("Log statements out of sync: current test suite was null");
+	}
     }
 
     private void requireTestSuite(String name) {
-        requireTestSuite();
-        if(name == null || !name.endsWith(currentTestSuite.getName())) {
-            throw new RuntimeException("Log statements out of sync: current test suite was '" + currentTestSuite.getName() + "' and not '" + name + "'");
-        }
+        currentTestSuite = testSuitesHash.get(name);
+	if(currentTestSuite==null) {
+	    // Swift 
+	    String[] testSuites = name.split(Pattern.quote("."));
+	    if ( testSuites.length == 2 ) {
+		String xctestName = testSuites[0] + ".xctest";
+		String testSuite = testSuites[1];
+		if ( !testSuitesHash.containsKey(xctestName) ) {
+		    throw new RuntimeException("Log statements out of sync: current test suite '" + xctestName + "' not exists");
+		}
+		currentTestSuite = testSuitesHash.get(testSuite);
+		if ( currentTestSuite == null ) {
+	    	    throw new RuntimeException("Log statements out of sync: current test suite '" + testSuite + "' not exists");
+		}
+	    }
+	}
     }
 
     private void requireTestCase(String name) {
+	currentTestCase = currentTestSuite.getTestCasesHash().get(name);
         if(currentTestCase==null) {
-            throw new RuntimeException("Log statements out of sync: current test case was null");
-        } else if(!currentTestCase.getName().equals(name)) {
-            throw new RuntimeException("Log statements out of sync: current test case was '" + currentTestCase.getName() + "'");
+            throw new RuntimeException("Log statements out of sync: current test case '" + currentTestSuite.getName() + "." + name + "' not exists");
         }
     }
 
@@ -175,76 +191,121 @@ public class XCodeBuildOutputParser {
     protected void handleLine(String line) throws ParseException, IOException, InterruptedException, JAXBException {
         Matcher m = START_SUITE.matcher(line);
         if(m.matches()) {
-        	  consoleLog = true;
+	    if (testSuitesHash.isEmpty()) {
+	    	consoleLog = true;
+	    }
+	    String suite_name = m.group(1);
+	    if ( m.group(1).endsWith(".xctest") ) {
+		suite_name = suite_name.replaceAll("-", "_");
+	    }
             currentTestSuite = new TestSuite(InetAddress.getLocalHost().getHostName(), m.group(1), parseDate(m.group(2)));
+	    testSuitesHash.put(suite_name, currentTestSuite);
             return;
         }
 
         m = END_SUITE.matcher(line);
         if(m.matches()) {
-            if(currentTestSuite==null) return; // if there is no current suite, do nothing
-
+            String suite_name = m.group(1);
+            if ( m.group(1).endsWith(".xctest") ) {
+                suite_name = suite_name.replaceAll("-", "_");
+            }
+	    requireTestSuite(suite_name);
             currentTestSuite.setEndTime(parseDate(m.group(2)));
             writeTestReport();
-
-            currentTestSuite = null;
-            consoleLog = false;
+            testSuitesHash.remove(suite_name);
+	    currentTestSuite = null;
+	    if ( testSuitesHash.size() == 1 ) {
+		// If the last test suitev in nhash is Unknown, process it and exit.
+		currentTestSuite = testSuitesHash.get("UnknownSuite");
+		if ( currentTestSuite != null ) {
+		    currentTestSuite.setEndTime(parseDate(m.group(2)));
+		    writeTestReport();
+		    testSuitesHash.remove(suite_name);
+		    currentTestSuite = null;
+		}
+	    }
+	    if (testSuitesHash.isEmpty()) {
+                consoleLog = false;
+	    }
             return;
         }
 
         m = START_TESTCASE.matcher(line);
         if(m.matches()) {
-            currentTestCase = new TestCase(currentTestSuite.getName(), m.group(1));
+	    requireTestSuite(m.group(1));
+	    currentTestCase = new TestCase(m.group(1), m.group(2));
+            currentTestSuite.getTestCasesHash().put(m.group(2), currentTestCase);
             return;
         }
 
         m = END_TESTCASE.matcher(line);
         if(m.matches()) {
-            requireTestSuite();
-            requireTestCase(m.group(1));
-
-            currentTestCase.setTime(Float.valueOf(m.group(2)));
+            requireTestSuite(m.group(1));
+            requireTestCase(m.group(2));
+            currentTestCase.setTime(Float.valueOf(m.group(3)));
             currentTestSuite.getTestCases().add(currentTestCase);
             currentTestSuite.addTest();
-            currentTestCase = null;
-            return;
-        }
+	    // Actually, I think that the test case should be closed and deleted here.
+	    // In case the error is reported late without synchronization.
+	    //currentTestSuite.getTestCasesHash().remove(m.group(2));
+	    currentTestCase = null;
+	    return;
+	}
 
         m = ERROR_TESTCASE.matcher(line);
         if(m.matches()) {
-
             String errorLocation = m.group(1);
             String testSuite = m.group(2);
             String testCase = m.group(3);
             String errorMessage = m.group(4);
-
             requireTestSuite(testSuite);
             requireTestCase(testCase);
-
             TestFailure failure = new TestFailure(errorMessage, errorLocation);
             currentTestCase.getFailures().add(failure);
             return;
         }
-	
+
+	// If the test result is returned asynchronously, there is a possibility
+	//  that in this case the target test can not be decided and information
+	//  is recorded in the wrong place.
         m = ERROR_UI_TESTCASE.matcher(line);
         if(m.matches()) {
             String errorLocation = m.group(1);
             String errorMessage = m.group(2);
-
             TestFailure failure = new TestFailure(errorMessage, errorLocation);
+
+ 	    if ( currentTestSuite == null ) {
+		currentTestSuite = testSuitesHash.get("UnknownSuite");
+		if ( currentTestSuite == null ) {
+ 		    currentTestSuite = new TestSuite(InetAddress.getLocalHost().getHostName(), "UnknownSuite", new Date());
+		    testSuitesHash.put("UnknownSuite", currentTestSuite);
+		}
+ 	    }
+                  
+	    if ( currentTestCase == null ) {
+		currentTestCase = currentTestSuite.getTestCasesHash().get("UnknownTestCase");
+		if ( currentTestCase == null ) {
+		    currentTestCase = new TestCase(currentTestSuite.getName(), "UnknownTestCase");
+		    currentTestSuite.getTestCasesHash().put("UnknownTestCase", currentTestCase);
+		    currentTestSuite.getTestCases().add(currentTestCase);
+		    currentTestSuite.addTest();
+		}
+	    }
+
             currentTestCase.getFailures().add(failure);
             return;
         }
 
         m = FAILED_TESTCASE.matcher(line);
         if(m.matches()) {
-            requireTestSuite();
-            requireTestCase(m.group(1));
+            requireTestSuite(m.group(1));
+            requireTestCase(m.group(2));
             currentTestSuite.addTest();
             currentTestSuite.addFailure();
-            currentTestCase.setTime(Float.valueOf(m.group(2)));
+            currentTestCase.setTime(Float.valueOf(m.group(3)));
             currentTestSuite.getTestCases().add(currentTestCase);
-            currentTestCase = null;
+	    //currentTestSuite.getTestCasesHash().remove(m.group(2));
+	    currentTestCase = null;
             return;
         }
 
@@ -261,16 +322,14 @@ public class XCodeBuildOutputParser {
         m = TERMINATING_EXCEPTION.matcher(line);
         if(m.matches()) {
             exitCode = -1;
-            
             requireTestSuite();
             if (currentTestCase != null) {
                 TestError error = new TestError(m.group(2), m.group(1));
                 currentTestCase.getErrors().add(error);
-                
                 currentTestSuite.getTestCases().add(currentTestCase);
                 currentTestSuite.addTest();
                 currentTestSuite.addError();
-                
+		//currentTestSuite.getTestCasesHash().remove(currentTestCase.getName());
                 currentTestCase = null;
             }
             writeTestReport();

--- a/src/main/java/au/com/rayh/report/TestSuite.java
+++ b/src/main/java/au/com/rayh/report/TestSuite.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -66,6 +67,8 @@ public class TestSuite {
     @XmlTransient
     Date startTime;
 
+    HashMap <String, TestCase> testCasesHash = new HashMap <String, TestCase>();
+
     public TestSuite() {
     }
     
@@ -74,6 +77,14 @@ public class TestSuite {
         this.hostname = hostname;
         this.name = name;
         this.startTime = startTime;
+    }
+
+    public HashMap<String, TestCase> getTestCasesHash() {
+	return testCasesHash;
+    }
+
+    public void setTestCasesHash(HashMap<String, TestCase> testCasesHash) {
+	this.testCasesHash = testCasesHash;
     }
 
     public int getFailures() {

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-logfileOutputDirectory.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-logfileOutputDirectory.html
@@ -1,0 +1,31 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2011 Ray Yamamoto Hilton
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    <p>
+      Specify the directory to output the log of xcodebuild.<br/>
+      If you leave it blank, it will be output to "project directory/builds/${BUILD_NUMBER}/log" with other logs.<br/>
+      If an output path is specified, it is output as a xcodebuild.log file in a relative directory under the "build output directory"
+    </p>
+</div>

--- a/src/main/resources/au/com/rayh/XCodeBuilder/help-logfileOutputDirectory_ja.html
+++ b/src/main/resources/au/com/rayh/XCodeBuilder/help-logfileOutputDirectory_ja.html
@@ -1,0 +1,31 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2011 Ray Yamamoto Hilton
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    <p>
+        xcodebuildのログを出力するディレクトリを指定します。<br/>
+        何も指定せずに空白のままにすると、他のログと共に "プロジェクトディレクトリ/builds/${BUILD_NUMBER}/log" へと出力されます。<br/>
+        出力パスを指定した場合には 「ビルドの出力ディレクトリ」 以下の相対ディレクトリに xcodebuild.log ファイルとして出力されます。<br/>
+    </p>
+</div>

--- a/src/test/java/au/com/rayh/JenkinsXCodeBuildOutputParserTest.java
+++ b/src/test/java/au/com/rayh/JenkinsXCodeBuildOutputParserTest.java
@@ -92,6 +92,7 @@ public class JenkinsXCodeBuildOutputParserTest {
     @After
     public void tearDown() {
     }
+
     @Test
     public void shouldIgnoreStartSuiteLineThatContainsFullPath() throws Exception {
     	test.shouldIgnoreStartSuiteLineThatContainsFullPath();

--- a/src/test/java/au/com/rayh/OutputParserTests.java
+++ b/src/test/java/au/com/rayh/OutputParserTests.java
@@ -49,13 +49,13 @@ class OutputParserTests {
     	parser = theParser;
     }
 
-	void shouldIgnoreStartSuiteLineThatContainsFullPath() throws Exception {
+    void shouldIgnoreStartSuiteLineThatContainsFullPath() throws Exception {
         String line = "Test Suite '/Users/ray/Development/Projects/Java/xcodebuild-hudson-plugin/work/jobs/PBS Streamer/workspace/build/Debug-iphonesimulator/TestSuite.octest(Tests)' started at 2010-10-02 13:39:22 GMT 0000";
         parser.handleLine(line);
         assertNull(parser.currentTestSuite);
     }
 
-	void shouldParseStartTestSuite() throws Exception {
+    void shouldParseStartTestSuite() throws Exception {
         String line = "Test Suite 'PisClientTestCase' started at 2010-10-02 13:39:23 GMT 0000";
         parser.handleLine(line);
         assertNotNull(parser.currentTestSuite);
@@ -63,15 +63,16 @@ class OutputParserTests {
         assertEquals(new Date(Date.UTC(110, 9, 2, 13, 39, 23)), parser.currentTestSuite.getStartTime());
     }
 
-	void shouldParseEndTestSuite() throws Exception {
+    void shouldParseEndTestSuite() throws Exception {
         parser.currentTestSuite = new TestSuite("host", "PisClientTestCase", new Date());
+	parser.testSuitesHash.put("PisClientTestCase", parser.currentTestSuite);
         String line = "Test Suite 'PisClientTestCase' finished at 2010-10-02 13:41:23 GMT 0000.";
         parser.handleLine(line);
         assertNull(parser.currentTestSuite);
         assertEquals(0, parser.exitCode);
     }
 
-	void shouldParseStartTestSuiteXC() throws Exception {
+    void shouldParseStartTestSuiteXC() throws Exception {
         String line = "Test Suite 'All tests' started at 2014-12-12 05:12:52 +0000";
         parser.handleLine(line);
         assertNotNull(parser.currentTestSuite);
@@ -79,25 +80,29 @@ class OutputParserTests {
         assertEquals(new Date(Date.UTC(114, 11, 12, 05, 12, 52)), parser.currentTestSuite.getStartTime());
     }
 
-	void shouldParseEndTestSuiteXC() throws Exception {
+    void shouldParseEndTestSuiteXC() throws Exception {
         parser.currentTestSuite = new TestSuite("host", "All tests", new Date());
+	parser.testSuitesHash.put("All tests", parser.currentTestSuite);
         String line = "Test Suite 'All tests' passed at 2014-12-12 05:12:52 +0000.";
         parser.handleLine(line);
         assertNull(parser.currentTestSuite);
         assertEquals(0, parser.exitCode);
     }
 
-	void shouldParseStartTestCase() throws Exception {
+    void shouldParseStartTestCase() throws Exception {
         parser.currentTestSuite = new TestSuite("host", "PisClientTestCase", new Date());
+	parser.testSuitesHash.put("PisClientTestCase", parser.currentTestSuite);
         String line = "Test Case '-[PisClientTestCase testThatFails]' started.";
         parser.handleLine(line);
         assertNotNull(parser.currentTestCase);
         assertEquals("testThatFails", parser.currentTestCase.getName());
     }
 
-	void shouldAddErrorToTestCase() throws Exception {
+    void shouldAddErrorToTestCase() throws Exception {
         parser.currentTestSuite = new TestSuite("host", "PisClientTestCase", new Date());
+	parser.testSuitesHash.put("PisClientTestCase", parser.currentTestSuite);
         parser.currentTestCase = new TestCase("PisClientTestCase", "testThatFails");
+	parser.currentTestSuite.getTestCasesHash().put("testThatFails", parser.currentTestCase);
         String line = "/Users/ray/Development/Projects/Java/xcodebuild-hudson-plugin/work/jobs/PBS Streamer/workspace/PisClientTestCase.m:21: error: -[PisClientTestCase testThatFails] : \"((nil) != nil)\" should be true. This always fails";
         parser.handleLine(line);
         assertEquals(1, parser.currentTestCase.getFailures().size());
@@ -105,9 +110,11 @@ class OutputParserTests {
         assertEquals("\"((nil) != nil)\" should be true. This always fails", parser.currentTestCase.getFailures().get(0).getMessage());
     }
 	
-	void shouldAddUIErrorToTestCase() throws Exception {
+    void shouldAddUIErrorToTestCase() throws Exception {
         parser.currentTestSuite = new TestSuite("host", "PisClientTestCase", new Date());
+	parser.testSuitesHash.put("PisClientTestCase", parser.currentTestSuite);
         parser.currentTestCase = new TestCase("PisClientTestCase", "testThatFails");
+	parser.currentTestSuite.getTestCasesHash().put("testThatFails", parser.currentTestCase);
         String line = "t =    29.77s             Assertion Failure: AppUITests.m:31: UI Testing Failure - No matches found for Alert";
         parser.handleLine(line);
         assertEquals(1, parser.currentTestCase.getFailures().size());
@@ -115,9 +122,11 @@ class OutputParserTests {
         assertEquals("UI Testing Failure - No matches found for Alert", parser.currentTestCase.getFailures().get(0).getMessage());
     }
 
-	void shouldParsePassedTestCase() throws Exception {
+    void shouldParsePassedTestCase() throws Exception {
         parser.currentTestSuite = new TestSuite("host", "PisClientTestCase", new Date());
+	parser.testSuitesHash.put("PisClientTestCase", parser.currentTestSuite);
         parser.currentTestCase = new TestCase("PisClientTestCase","testThatPasses");
+	parser.currentTestSuite.getTestCasesHash().put("testThatPasses", parser.currentTestCase);
         String line = "Test Case '-[PisClientTestCase testThatPasses]' passed (1.234 seconds).";
         parser.handleLine(line);
         assertNull(parser.currentTestCase);
@@ -128,9 +137,11 @@ class OutputParserTests {
         assertEquals(0,parser.currentTestSuite.getFailures());
     }
 
-	void shouldParseFailedTestCase() throws Exception {
+    void shouldParseFailedTestCase() throws Exception {
         parser.currentTestSuite = new TestSuite("host", "PisClientTestCase", new Date());
+	parser.testSuitesHash.put("PisClientTestCase", parser.currentTestSuite);
         parser.currentTestCase = new TestCase("PisClientTestCase","testThatFails");
+	parser.currentTestSuite.getTestCasesHash().put("testThatFails", parser.currentTestCase);
         String line = "Test Case '-[PisClientTestCase testThatFails]' failed (1.234 seconds).";
         parser.handleLine(line);
         assertNull(parser.currentTestCase);

--- a/src/test/java/au/com/rayh/XCodeBuildOutputParserTest.java
+++ b/src/test/java/au/com/rayh/XCodeBuildOutputParserTest.java
@@ -139,4 +139,18 @@ public class XCodeBuildOutputParserTest {
         IOUtils.copy(getClass().getResourceAsStream(outputFileName), parser.captureOutputStream);
         return parser;
     }
+
+    // JENKINS-37072
+    @Test
+    public void shouldParseFullXCPassingTestComplex1() throws IOException {
+	XCodeBuildOutputParser parser = parseTestOutput("/XCTest_output_complex_1.txt");
+	assertEquals(-1, parser.getExitCode());
+    }
+
+    // JENKINS-37072
+    @Test
+    public void shouldParseFullXCPassingTestComplex2() throws IOException {
+	XCodeBuildOutputParser parser = parseTestOutput("/XCTest_output_complex_2.txt");
+	assertEquals(-1, parser.getExitCode());
+    }
 }

--- a/src/test/resources/XCTest_output_complex_1.txt
+++ b/src/test/resources/XCTest_output_complex_1.txt
@@ -1,0 +1,385 @@
+Test Suite 'All tests' started at 2018-05-17 07:07:31.814
+Test Suite 'XCUITests-ExampleTests.xctest' started at 2018-05-17 07:07:31.815
+Test Suite 'Objc_Test_Under_Score_Tests' started at 2018-05-17 07:07:31.816
+Test Case '-[Objc_Test_Under_Score_Tests testExample]' started.
+Test Case '-[Objc_Test_Under_Score_Tests testExample]' passed (0.001 seconds).
+Test Case '-[Objc_Test_Under_Score_Tests testPerformanceExample]' started.
+Test Case '-[Objc_Test_Under_Score_Tests testPerformanceExample]' passed (0.339 seconds).
+Test Suite 'Objc_Test_Under_Score_Tests' passed at 2018-05-17 07:07:32.157.
+Test Suite 'Objec_SubTests' started at 2018-05-17 07:07:32.157
+Test Case '-[Objec_SubTests testExample]' started.
+Test Case '-[Objec_SubTests testExample]' passed (0.000 seconds).
+Test Case '-[Objec_SubTests testPerformanceExample]' started.
+Test Case '-[Objec_SubTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'Objec_SubTests' passed at 2018-05-17 07:07:32.410.
+Test Suite 'RaiseAnExceptionTests' started at 2018-05-17 07:07:32.411
+Test Case '-[RaiseAnExceptionTests testExample1]' started.
+/Volumes/RAID10HDD/iOS/XCUITests_Example/XCUITests_ExampleTests/RaiseAnExceptionTests.m:32: error: -[RaiseAnExceptionTests testExample1] : failed: caught "NSRangeException", "*** -[__NSArrayI objectAtIndex:]: index 11 beyond bounds [0 .. 2]"
+Test Case '-[RaiseAnExceptionTests testExample1]' failed (0.015 seconds).
+Test Case '-[RaiseAnExceptionTests testExample2]' started.
+/Volumes/RAID10HDD/iOS/XCUITests_Example/XCUITests_ExampleTests/RaiseAnExceptionTests.m:40: error: -[RaiseAnExceptionTests testExample2] : ((result) equal to (@"value1")) failed: ("value2") is not equal to ("value1")
+Test Case '-[RaiseAnExceptionTests testExample2]' failed (0.001 seconds).
+Test Case '-[RaiseAnExceptionTests testExample3]' started.
+Test Case '-[RaiseAnExceptionTests testExample3]' passed (0.000 seconds).
+Test Case '-[RaiseAnExceptionTests testPerformanceExample]' started.
+Test Case '-[RaiseAnExceptionTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'RaiseAnExceptionTests' failed at 2018-05-17 07:07:32.681.
+Test Suite 'Swift_SubTests' started at 2018-05-17 07:07:32.682
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample1]' started.
+<unknown>:0: error: -[XCUITests_ExampleTests.Swift_SubTests testExample1] : failed: caught "NSRangeException", "*** -[__NSArrayI objectAtIndex:]: index 10 beyond bounds [0 .. 2]"
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample1]' failed (0.013 seconds).
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample2]' started.
+/Volumes/RAID10HDD/iOS/XCUITests_Example/XCUITests_ExampleTests/SubTests/Swift_SubTests.swift:36: error: -[XCUITests_ExampleTests.Swift_SubTests testExample2] : XCTAssertEqual failed: ("Optional("value2")") is not equal to ("Optional("value1")") - 
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample2]' failed (0.005 seconds).
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample3]' started.
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample3]' passed (0.000 seconds).
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testPerformanceExample]' started.
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'Swift_SubTests' failed at 2018-05-17 07:07:32.955.
+Test Suite 'Swift_Test_Under_Score_Tests' started at 2018-05-17 07:07:32.956
+Test Case '-[XCUITests_ExampleTests.Swift_Test_Under_Score_Tests testExample]' started.
+Test Case '-[XCUITests_ExampleTests.Swift_Test_Under_Score_Tests testExample]' passed (0.001 seconds).
+Test Case '-[XCUITests_ExampleTests.Swift_Test_Under_Score_Tests testPerformanceExample]' started.
+Test Case '-[XCUITests_ExampleTests.Swift_Test_Under_Score_Tests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'Swift_Test_Under_Score_Tests' passed at 2018-05-17 07:07:33.210.
+Test Suite 'XCUITests_AnotherTests' started at 2018-05-17 07:07:33.210
+Test Case '-[XCUITests_AnotherTests testExample]' started.
+Test Case '-[XCUITests_AnotherTests testExample]' passed (0.001 seconds).
+Test Case '-[XCUITests_AnotherTests testPerformanceExample]' started.
+Test Case '-[XCUITests_AnotherTests testPerformanceExample]' passed (0.253 seconds).
+Test Suite 'XCUITests_AnotherTests' passed at 2018-05-17 07:07:33.464.
+Test Suite 'XCUITests_ExampleTests' started at 2018-05-17 07:07:33.465
+Test Case '-[XCUITests_ExampleTests testExample]' started.
+Test Case '-[XCUITests_ExampleTests testExample]' passed (0.001 seconds).
+Test Case '-[XCUITests_ExampleTests testPerformanceExample]' started.
+Test Case '-[XCUITests_ExampleTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'XCUITests_ExampleTests' passed at 2018-05-17 07:07:33.718.
+Test Suite 'XCUITests_SubTests' started at 2018-05-17 07:07:33.719
+Test Case '-[XCUITests_SubTests testExample]' started.
+Test Case '-[XCUITests_SubTests testExample]' passed (0.000 seconds).
+Test Case '-[XCUITests_SubTests testPerformanceExample]' started.
+Test Case '-[XCUITests_SubTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'XCUITests_SubTests' passed at 2018-05-17 07:07:33.972.
+Test Suite 'XCUITests_SwiftTests' started at 2018-05-17 07:07:33.973
+Test Case '-[XCUITests_ExampleTests.XCUITests_SwiftTests testExample]' started.
+Test Case '-[XCUITests_ExampleTests.XCUITests_SwiftTests testExample]' passed (0.001 seconds).
+Test Case '-[XCUITests_ExampleTests.XCUITests_SwiftTests testPerformanceExample]' started.
+Test Case '-[XCUITests_ExampleTests.XCUITests_SwiftTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'XCUITests_SwiftTests' passed at 2018-05-17 07:07:34.227.
+Test Suite 'XCUITests-ExampleTests.xctest' failed at 2018-05-17 07:07:34.227.
+Test Suite 'All tests' failed at 2018-05-17 07:07:34.228.
+Test Suite 'All tests' started at 2018-05-17 07:07:40.691
+Test Suite 'XCUITests-ExampleUITests.xctest' started at 2018-05-17 07:07:40.692
+Test Suite 'XCUITests_ExampleUITests' started at 2018-05-17 07:07:40.693
+Test Case '-[XCUITests_ExampleUITests testExample]' started.
+    t =     0.00s Start Test at 2018-05-17 07:07:40.693
+    t =     0.07s Set Up
+    t =     0.07s     Open net.hoge2.XCUITests-Example
+    t =     0.12s         Launch net.hoge2.XCUITests-Example
+    t =     5.04s             Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.21s Tap "Add" Button
+    t =     6.22s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.26s     Find the "Add" Button
+    t =     6.26s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     6.30s         Find: Descendants matching type NavigationBar
+    t =     6.30s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     6.31s         Find: Descendants matching type Button
+    t =     6.31s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     6.41s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.46s     Synthesize event
+    t =     6.59s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.08s Tap "Add" Button
+    t =     7.08s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.12s     Find the "Add" Button
+    t =     7.13s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     7.15s         Find: Descendants matching type NavigationBar
+    t =     7.15s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     7.16s         Find: Descendants matching type Button
+    t =     7.16s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     7.26s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.31s     Synthesize event
+    t =     7.43s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.90s Tap Cell
+    t =     7.90s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.95s     Find the Cell
+    t =     7.95s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     7.98s         Find: Descendants matching type Table
+    t =     7.98s         Find: Descendants matching type Cell
+    t =     7.98s         Find: Element at index 0
+    t =     8.08s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.13s     Synthesize event
+    t =     8.26s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.79s Tap "Master" Button
+    t =     8.79s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.85s     Find the "Master" Button
+    t =     8.85s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     8.87s         Find: Descendants matching type NavigationBar
+    t =     8.87s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =     8.87s         Find: Descendants matching type Button
+    t =     8.87s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     8.98s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.03s     Synthesize event
+    t =     9.15s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.67s Tap Cell
+    t =     9.67s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.73s     Find the Cell
+    t =     9.73s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     9.75s         Find: Descendants matching type Table
+    t =     9.75s         Find: Descendants matching type Cell
+    t =     9.75s         Find: Element at index 1
+    t =     9.86s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.91s     Synthesize event
+    t =    10.03s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.56s Tap "Master" Button
+    t =    10.56s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.62s     Find the "Master" Button
+    t =    10.62s         Snapshot accessibility hierarchy for app with pid 39901
+    t =    10.64s         Find: Descendants matching type NavigationBar
+    t =    10.64s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =    10.64s         Find: Descendants matching type Button
+    t =    10.64s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    10.75s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.80s     Synthesize event
+    t =    10.92s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.44s Tap "Edit" Button
+    t =    11.44s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.49s     Find the "Edit" Button
+    t =    11.50s         Snapshot accessibility hierarchy for app with pid 39901
+    t =    11.52s         Find: Descendants matching type NavigationBar
+    t =    11.52s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    11.52s         Find: Descendants matching type Button
+    t =    11.52s         Find: Elements matching predicate '"Edit" IN identifiers'
+    t =    11.63s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.67s     Synthesize event
+    t =    11.79s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.28s Tap "Done" Button
+    t =    12.28s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.33s     Find the "Done" Button
+    t =    12.33s         Snapshot accessibility hierarchy for app with pid 39901
+    t =    12.36s         Find: Descendants matching type NavigationBar
+    t =    12.36s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    12.36s         Find: Descendants matching type Button
+    t =    12.36s         Find: Elements matching predicate '"Done" IN identifiers'
+    t =    12.47s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.52s     Synthesize event
+    t =    12.64s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    13.11s Tear Down
+Test Case '-[XCUITests_ExampleUITests testExample]' passed (13.316 seconds).
+Test Suite 'XCUITests_ExampleUITests' passed at 2018-05-17 07:07:54.010.
+Test Suite 'XCUITests_ExampleUITestsFail' started at 2018-05-17 07:07:54.011
+Test Case '-[XCUITests_ExampleUITestsFail testExample]' started.
+    t =     0.00s Start Test at 2018-05-17 07:07:54.012
+    t =     0.05s Set Up
+    t =     0.15s     Open net.hoge2.XCUITests-Example
+    t =     0.19s         Launch net.hoge2.XCUITests-Example
+    t =     0.19s             Terminate net.hoge2.XCUITests-Example:39901
+    t =     5.29s             Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.45s Tap "Add" Button
+    t =     6.45s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.49s     Find the "Add" Button
+    t =     6.50s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     6.53s         Find: Descendants matching type NavigationBar
+    t =     6.54s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     6.54s         Find: Descendants matching type Button
+    t =     6.54s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     6.64s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.69s     Synthesize event
+    t =     6.82s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.30s Tap "Add" Button
+    t =     7.30s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.35s     Find the "Add" Button
+    t =     7.35s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     7.38s         Find: Descendants matching type NavigationBar
+    t =     7.38s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     7.38s         Find: Descendants matching type Button
+    t =     7.38s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     7.49s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.54s     Synthesize event
+    t =     7.66s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.13s Tap Cell
+    t =     8.13s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.18s     Find the Cell
+    t =     8.18s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     8.20s         Find: Descendants matching type Table
+    t =     8.20s         Find: Descendants matching type Cell
+    t =     8.21s         Find: Element at index 0
+    t =     8.31s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.36s     Synthesize event
+    t =     8.49s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.02s Tap "Master" Button
+    t =     9.02s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.08s     Find the "Master" Button
+    t =     9.08s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     9.10s         Find: Descendants matching type NavigationBar
+    t =     9.10s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =     9.10s         Find: Descendants matching type Button
+    t =     9.10s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     9.21s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.26s     Synthesize event
+    t =     9.38s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.90s Tap Cell
+    t =     9.90s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.95s     Find the Cell
+    t =     9.95s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     9.98s         Find: Descendants matching type Table
+    t =     9.98s         Find: Descendants matching type Cell
+    t =     9.98s         Find: Element at index 1
+    t =    10.08s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.13s     Synthesize event
+    t =    10.26s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.78s Tap "Master" Button
+    t =    10.78s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.83s     Find the "Master" Button
+    t =    10.83s         Snapshot accessibility hierarchy for app with pid 39907
+    t =    10.85s         Find: Descendants matching type NavigationBar
+    t =    10.85s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =    10.85s         Find: Descendants matching type Button
+    t =    10.85s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    10.96s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.01s     Synthesize event
+    t =    11.12s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.64s Tap "Edit" Button
+    t =    11.64s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.69s     Find the "Edit" Button
+    t =    11.69s         Snapshot accessibility hierarchy for app with pid 39907
+    t =    11.71s         Find: Descendants matching type NavigationBar
+    t =    11.71s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    11.72s         Find: Descendants matching type Button
+    t =    11.72s         Find: Elements matching predicate '"Edit" IN identifiers'
+    t =    11.82s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.87s     Synthesize event
+    t =    11.99s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.47s Tap Cell
+    t =    12.47s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.52s     Find the Cell
+    t =    12.52s         Snapshot accessibility hierarchy for app with pid 39907
+    t =    12.54s         Find: Descendants matching type Table
+    t =    12.54s         Find: Descendants matching type Cell
+    t =    12.54s         Find: Element at index 0
+    t =    12.65s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.70s     Synthesize event
+    t =    12.82s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.87s Tap "Delete" Button
+    t =    12.87s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.91s     Find the "Delete" Button
+    t =    12.92s         Snapshot accessibility hierarchy for app with pid 39907
+    t =    12.94s         Find: Descendants matching type Table
+    t =    12.94s         Find: Descendants matching type Button
+    t =    12.94s         Find: Elements matching predicate '"Delete" IN identifiers'
+    t =    13.05s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    14.10s         Find the "Delete" Button (retry 1)
+    t =    14.10s             Snapshot accessibility hierarchy for app with pid 39907
+    t =    14.12s             Find: Descendants matching type Table
+    t =    14.13s             Find: Descendants matching type Button
+    t =    14.13s             Find: Elements matching predicate '"Delete" IN identifiers'
+    t =    14.23s             Wait for net.hoge2.XCUITests-Example to idle
+    t =    15.28s         Find the "Delete" Button (retry 2)
+    t =    15.29s             Snapshot accessibility hierarchy for app with pid 39907
+    t =    15.31s             Find: Descendants matching type Table
+    t =    15.31s             Find: Descendants matching type Button
+    t =    15.31s             Find: Elements matching predicate '"Delete" IN identifiers'
+    t =    15.42s             Wait for net.hoge2.XCUITests-Example to idle
+    t =    15.52s         Assertion Failure: XCUITests_ExampleUITestsFail.m:57: No matches found for Find: Elements matching predicate '"Delete" IN identifiers' from input {(
+** TEST FAILED **
+    t =    15.56s Tear Down
+Test Case '-[XCUITests_ExampleUITestsFail testExample]' failed (15.769 seconds).
+Test Suite 'XCUITests_ExampleUITestsFail' failed at 2018-05-17 07:08:09.782.
+Test Suite 'XCUITests_SubUITests' started at 2018-05-17 07:08:09.783
+Test Case '-[XCUITests_SubUITests testExample]' started.
+    t =     0.00s Start Test at 2018-05-17 07:08:09.784
+    t =     0.04s Set Up
+    t =     0.14s     Open net.hoge2.XCUITests-Example
+    t =     0.18s         Launch net.hoge2.XCUITests-Example
+    t =     0.18s             Terminate net.hoge2.XCUITests-Example:39907
+    t =     5.27s             Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.46s Tap "Add" Button
+    t =     6.46s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.51s     Find the "Add" Button
+    t =     6.51s         Snapshot accessibility hierarchy for app with pid 39915
+    t =     6.55s         Find: Descendants matching type NavigationBar
+    t =     6.55s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     6.55s         Find: Descendants matching type Button
+    t =     6.56s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     6.66s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.71s     Synthesize event
+    t =     6.85s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.33s Tap "Add" Button
+    t =     7.33s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.39s     Find the "Add" Button
+    t =     7.39s         Snapshot accessibility hierarchy for app with pid 39915
+    t =     7.42s         Find: Descendants matching type NavigationBar
+    t =     7.42s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     7.42s         Find: Descendants matching type Button
+    t =     7.42s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     7.53s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.57s     Synthesize event
+    t =     7.69s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.17s Tap Cell
+    t =     8.17s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.22s     Find the Cell
+    t =     8.22s         Snapshot accessibility hierarchy for app with pid 39915
+    t =     8.24s         Find: Descendants matching type Table
+    t =     8.24s         Find: Descendants matching type Cell
+    t =     8.24s         Find: Element at index 0
+    t =     8.35s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.40s     Synthesize event
+    t =     8.52s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.06s Tap "Master" Button
+    t =     9.06s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.12s     Find the "Master" Button
+    t =     9.12s         Snapshot accessibility hierarchy for app with pid 39915
+    t =     9.15s         Find: Descendants matching type NavigationBar
+    t =     9.15s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =     9.15s         Find: Descendants matching type Button
+    t =     9.15s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     9.26s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.31s     Synthesize event
+    t =     9.44s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.95s Tap Cell
+    t =     9.95s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.01s     Find the Cell
+    t =    10.01s         Snapshot accessibility hierarchy for app with pid 39915
+    t =    10.03s         Find: Descendants matching type Table
+    t =    10.04s         Find: Descendants matching type Cell
+    t =    10.04s         Find: Element at index 1
+    t =    10.14s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.20s     Synthesize event
+    t =    10.33s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.85s Tap "Master" Button
+    t =    10.85s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.90s     Find the "Master" Button
+    t =    10.90s         Snapshot accessibility hierarchy for app with pid 39915
+    t =    10.92s         Find: Descendants matching type NavigationBar
+    t =    10.93s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =    10.93s         Find: Descendants matching type Button
+    t =    10.93s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    11.04s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.09s     Synthesize event
+    t =    11.21s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.72s Tap "Edit" Button
+    t =    11.72s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.78s     Find the "Edit" Button
+    t =    11.78s         Snapshot accessibility hierarchy for app with pid 39915
+    t =    11.81s         Find: Descendants matching type NavigationBar
+    t =    11.81s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    11.81s         Find: Descendants matching type Button
+    t =    11.81s         Find: Elements matching predicate '"Edit" IN identifiers'
+    t =    11.91s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.96s     Synthesize event
+    t =    12.08s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.56s Tap "Done" Button
+    t =    12.56s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.62s     Find the "Done" Button
+    t =    12.62s         Snapshot accessibility hierarchy for app with pid 39915
+    t =    12.65s         Find: Descendants matching type NavigationBar
+    t =    12.65s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    12.65s         Find: Descendants matching type Button
+    t =    12.65s         Find: Elements matching predicate '"Done" IN identifiers'
+    t =    12.76s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.81s     Synthesize event
+    t =    12.93s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    13.41s Tear Down
+Test Case '-[XCUITests_SubUITests testExample]' passed (13.610 seconds).
+Test Suite 'XCUITests_SubUITests' passed at 2018-05-17 07:08:23.394.
+Test Suite 'XCUITests-ExampleUITests.xctest' failed at 2018-05-17 07:08:23.395.
+Test Suite 'All tests' failed at 2018-05-17 07:08:23.396.

--- a/src/test/resources/XCTest_output_complex_2.txt
+++ b/src/test/resources/XCTest_output_complex_2.txt
@@ -1,0 +1,386 @@
+Test Suite 'All tests' started at 2018-05-17 07:07:31.814
+Test Suite 'XCUITests-ExampleTests.xctest' started at 2018-05-17 07:07:31.815
+Test Suite 'Objc_Test_Under_Score_Tests' started at 2018-05-17 07:07:31.816
+Test Case '-[Objc_Test_Under_Score_Tests testExample]' started.
+Test Case '-[Objc_Test_Under_Score_Tests testExample]' passed (0.001 seconds).
+Test Case '-[Objc_Test_Under_Score_Tests testPerformanceExample]' started.
+Test Case '-[Objc_Test_Under_Score_Tests testPerformanceExample]' passed (0.339 seconds).
+Test Suite 'Objc_Test_Under_Score_Tests' passed at 2018-05-17 07:07:32.157.
+Test Suite 'Objec_SubTests' started at 2018-05-17 07:07:32.157
+Test Case '-[Objec_SubTests testExample]' started.
+Test Case '-[Objec_SubTests testExample]' passed (0.000 seconds).
+Test Case '-[Objec_SubTests testPerformanceExample]' started.
+Test Case '-[Objec_SubTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'Objec_SubTests' passed at 2018-05-17 07:07:32.410.
+Test Suite 'RaiseAnExceptionTests' started at 2018-05-17 07:07:32.411
+Test Case '-[RaiseAnExceptionTests testExample1]' started.
+/Volumes/RAID10HDD/iOS/XCUITests_Example/XCUITests_ExampleTests/RaiseAnExceptionTests.m:32: error: -[RaiseAnExceptionTests testExample1] : failed: caught "NSRangeException", "*** -[__NSArrayI objectAtIndex:]: index 11 beyond bounds [0 .. 2]"
+Test Case '-[RaiseAnExceptionTests testExample2]' started.
+/Volumes/RAID10HDD/iOS/XCUITests_Example/XCUITests_ExampleTests/RaiseAnExceptionTests.m:40: error: -[RaiseAnExceptionTests testExample2] : ((result) equal to (@"value1")) failed: ("value2") is not equal to ("value1")
+Test Case '-[RaiseAnExceptionTests testExample2]' failed (0.001 seconds).
+Test Case '-[RaiseAnExceptionTests testExample3]' started.
+Test Case '-[RaiseAnExceptionTests testExample1]' failed (0.015 seconds).
+Test Case '-[RaiseAnExceptionTests testExample3]' passed (0.000 seconds).
+Test Case '-[RaiseAnExceptionTests testPerformanceExample]' started.
+Test Case '-[RaiseAnExceptionTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'RaiseAnExceptionTests' failed at 2018-05-17 07:07:32.681.
+Test Suite 'Swift_SubTests' started at 2018-05-17 07:07:32.682
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample1]' started.
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample1]' failed (0.013 seconds).
+<unknown>:0: error: -[XCUITests_ExampleTests.Swift_SubTests testExample1] : failed: caught "NSRangeException", "*** -[__NSArrayI objectAtIndex:]: index 10 beyond bounds [0 .. 2]"
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample2]' started.
+/Volumes/RAID10HDD/iOS/XCUITests_Example/XCUITests_ExampleTests/SubTests/Swift_SubTests.swift:36: error: -[XCUITests_ExampleTests.Swift_SubTests testExample2] : XCTAssertEqual failed: ("Optional("value2")") is not equal to ("Optional("value1")") - 
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample2]' failed (0.005 seconds).
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample3]' started.
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testExample3]' passed (0.000 seconds).
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testPerformanceExample]' started.
+Test Case '-[XCUITests_ExampleTests.Swift_SubTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'Swift_SubTests' failed at 2018-05-17 07:07:32.955.
+Test Suite 'Swift_Test_Under_Score_Tests' started at 2018-05-17 07:07:32.956
+Test Case '-[XCUITests_ExampleTests.Swift_Test_Under_Score_Tests testExample]' started.
+Test Case '-[XCUITests_ExampleTests.Swift_Test_Under_Score_Tests testExample]' passed (0.001 seconds).
+Test Case '-[XCUITests_ExampleTests.Swift_Test_Under_Score_Tests testPerformanceExample]' started.
+Test Case '-[XCUITests_ExampleTests.Swift_Test_Under_Score_Tests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'Swift_Test_Under_Score_Tests' passed at 2018-05-17 07:07:33.210.
+Test Suite 'XCUITests_AnotherTests' started at 2018-05-17 07:07:33.210
+Test Case '-[XCUITests_AnotherTests testExample]' started.
+Test Case '-[XCUITests_AnotherTests testExample]' passed (0.001 seconds).
+Test Case '-[XCUITests_AnotherTests testPerformanceExample]' started.
+Test Case '-[XCUITests_AnotherTests testPerformanceExample]' passed (0.253 seconds).
+Test Suite 'XCUITests_AnotherTests' passed at 2018-05-17 07:07:33.464.
+Test Suite 'XCUITests_ExampleTests' started at 2018-05-17 07:07:33.465
+Test Case '-[XCUITests_ExampleTests testExample]' started.
+Test Case '-[XCUITests_ExampleTests testExample]' passed (0.001 seconds).
+Test Case '-[XCUITests_ExampleTests testPerformanceExample]' started.
+Test Case '-[XCUITests_ExampleTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'XCUITests_ExampleTests' passed at 2018-05-17 07:07:33.718.
+Test Suite 'XCUITests_SubTests' started at 2018-05-17 07:07:33.719
+Test Case '-[XCUITests_SubTests testExample]' started.
+Test Case '-[XCUITests_SubTests testExample]' passed (0.000 seconds).
+Test Case '-[XCUITests_SubTests testPerformanceExample]' started.
+Test Case '-[XCUITests_SubTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'XCUITests_SubTests' passed at 2018-05-17 07:07:33.972.
+Test Suite 'XCUITests_SwiftTests' started at 2018-05-17 07:07:33.973
+Test Case '-[XCUITests_ExampleTests.XCUITests_SwiftTests testExample]' started.
+Test Case '-[XCUITests_ExampleTests.XCUITests_SwiftTests testExample]' passed (0.001 seconds).
+Test Case '-[XCUITests_ExampleTests.XCUITests_SwiftTests testPerformanceExample]' started.
+Test Case '-[XCUITests_ExampleTests.XCUITests_SwiftTests testPerformanceExample]' passed (0.252 seconds).
+Test Suite 'XCUITests_SwiftTests' passed at 2018-05-17 07:07:34.227.
+Test Suite 'XCUITests-ExampleTests.xctest' failed at 2018-05-17 07:07:34.227.
+Test Suite 'All tests' failed at 2018-05-17 07:07:34.228.
+Test Suite 'All tests' started at 2018-05-17 07:07:40.691
+Test Suite 'XCUITests-ExampleUITests.xctest' started at 2018-05-17 07:07:40.692
+Test Suite 'XCUITests_ExampleUITests' started at 2018-05-17 07:07:40.693
+Test Case '-[XCUITests_ExampleUITests testExample]' started.
+    t =     0.00s Start Test at 2018-05-17 07:07:40.693
+    t =     0.07s Set Up
+    t =     0.07s     Open net.hoge2.XCUITests-Example
+    t =     0.12s         Launch net.hoge2.XCUITests-Example
+    t =     5.04s             Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.21s Tap "Add" Button
+    t =     6.22s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.26s     Find the "Add" Button
+    t =     6.26s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     6.30s         Find: Descendants matching type NavigationBar
+    t =     6.30s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     6.31s         Find: Descendants matching type Button
+    t =     6.31s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     6.41s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.46s     Synthesize event
+    t =     6.59s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.08s Tap "Add" Button
+    t =     7.08s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.12s     Find the "Add" Button
+    t =     7.13s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     7.15s         Find: Descendants matching type NavigationBar
+    t =     7.15s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     7.16s         Find: Descendants matching type Button
+    t =     7.16s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     7.26s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.31s     Synthesize event
+    t =     7.43s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.90s Tap Cell
+    t =     7.90s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.95s     Find the Cell
+    t =     7.95s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     7.98s         Find: Descendants matching type Table
+    t =     7.98s         Find: Descendants matching type Cell
+    t =     7.98s         Find: Element at index 0
+    t =     8.08s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.13s     Synthesize event
+    t =     8.26s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.79s Tap "Master" Button
+    t =     8.79s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.85s     Find the "Master" Button
+    t =     8.85s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     8.87s         Find: Descendants matching type NavigationBar
+    t =     8.87s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =     8.87s         Find: Descendants matching type Button
+    t =     8.87s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     8.98s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.03s     Synthesize event
+    t =     9.15s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.67s Tap Cell
+    t =     9.67s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.73s     Find the Cell
+    t =     9.73s         Snapshot accessibility hierarchy for app with pid 39901
+    t =     9.75s         Find: Descendants matching type Table
+    t =     9.75s         Find: Descendants matching type Cell
+    t =     9.75s         Find: Element at index 1
+    t =     9.86s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.91s     Synthesize event
+    t =    10.03s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.56s Tap "Master" Button
+    t =    10.56s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.62s     Find the "Master" Button
+    t =    10.62s         Snapshot accessibility hierarchy for app with pid 39901
+    t =    10.64s         Find: Descendants matching type NavigationBar
+    t =    10.64s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =    10.64s         Find: Descendants matching type Button
+    t =    10.64s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    10.75s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.80s     Synthesize event
+    t =    10.92s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.44s Tap "Edit" Button
+    t =    11.44s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.49s     Find the "Edit" Button
+    t =    11.50s         Snapshot accessibility hierarchy for app with pid 39901
+    t =    11.52s         Find: Descendants matching type NavigationBar
+    t =    11.52s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    11.52s         Find: Descendants matching type Button
+    t =    11.52s         Find: Elements matching predicate '"Edit" IN identifiers'
+    t =    11.63s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.67s     Synthesize event
+    t =    11.79s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.28s Tap "Done" Button
+    t =    12.28s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.33s     Find the "Done" Button
+    t =    12.33s         Snapshot accessibility hierarchy for app with pid 39901
+    t =    12.36s         Find: Descendants matching type NavigationBar
+    t =    12.36s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    12.36s         Find: Descendants matching type Button
+    t =    12.36s         Find: Elements matching predicate '"Done" IN identifiers'
+    t =    12.47s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.52s     Synthesize event
+    t =    12.64s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    13.11s Tear Down
+Test Case '-[XCUITests_ExampleUITests testExample]' passed (13.316 seconds).
+Test Suite 'XCUITests_ExampleUITests' passed at 2018-05-17 07:07:54.010.
+Test Suite 'XCUITests_ExampleUITestsFail' started at 2018-05-17 07:07:54.011
+Test Case '-[XCUITests_ExampleUITestsFail testExample]' started.
+    t =     0.00s Start Test at 2018-05-17 07:07:54.012
+    t =     0.05s Set Up
+    t =     0.15s     Open net.hoge2.XCUITests-Example
+    t =     0.19s         Launch net.hoge2.XCUITests-Example
+    t =     0.19s             Terminate net.hoge2.XCUITests-Example:39901
+    t =     5.29s             Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.45s Tap "Add" Button
+    t =     6.45s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.49s     Find the "Add" Button
+    t =     6.50s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     6.53s         Find: Descendants matching type NavigationBar
+    t =     6.54s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     6.54s         Find: Descendants matching type Button
+    t =     6.54s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     6.64s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.69s     Synthesize event
+    t =     6.82s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.30s Tap "Add" Button
+    t =     7.30s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.35s     Find the "Add" Button
+    t =     7.35s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     7.38s         Find: Descendants matching type NavigationBar
+    t =     7.38s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     7.38s         Find: Descendants matching type Button
+    t =     7.38s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     7.49s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.54s     Synthesize event
+    t =     7.66s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.13s Tap Cell
+    t =     8.13s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.18s     Find the Cell
+    t =     8.18s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     8.20s         Find: Descendants matching type Table
+    t =     8.20s         Find: Descendants matching type Cell
+    t =     8.21s         Find: Element at index 0
+    t =     8.31s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.36s     Synthesize event
+    t =     8.49s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.02s Tap "Master" Button
+    t =     9.02s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.08s     Find the "Master" Button
+    t =     9.08s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     9.10s         Find: Descendants matching type NavigationBar
+    t =     9.10s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =     9.10s         Find: Descendants matching type Button
+    t =     9.10s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     9.21s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.26s     Synthesize event
+    t =     9.38s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.90s Tap Cell
+    t =     9.90s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.95s     Find the Cell
+    t =     9.95s         Snapshot accessibility hierarchy for app with pid 39907
+    t =     9.98s         Find: Descendants matching type Table
+    t =     9.98s         Find: Descendants matching type Cell
+    t =     9.98s         Find: Element at index 1
+    t =    10.08s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.13s     Synthesize event
+    t =    10.26s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.78s Tap "Master" Button
+    t =    10.78s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.83s     Find the "Master" Button
+    t =    10.83s         Snapshot accessibility hierarchy for app with pid 39907
+    t =    10.85s         Find: Descendants matching type NavigationBar
+    t =    10.85s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =    10.85s         Find: Descendants matching type Button
+    t =    10.85s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    10.96s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.01s     Synthesize event
+    t =    11.12s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.64s Tap "Edit" Button
+    t =    11.64s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.69s     Find the "Edit" Button
+    t =    11.69s         Snapshot accessibility hierarchy for app with pid 39907
+    t =    11.71s         Find: Descendants matching type NavigationBar
+    t =    11.71s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    11.72s         Find: Descendants matching type Button
+    t =    11.72s         Find: Elements matching predicate '"Edit" IN identifiers'
+    t =    11.82s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.87s     Synthesize event
+    t =    11.99s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.47s Tap Cell
+    t =    12.47s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.52s     Find the Cell
+    t =    12.52s         Snapshot accessibility hierarchy for app with pid 39907
+    t =    12.54s         Find: Descendants matching type Table
+    t =    12.54s         Find: Descendants matching type Cell
+    t =    12.54s         Find: Element at index 0
+    t =    12.65s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.70s     Synthesize event
+    t =    12.82s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.87s Tap "Delete" Button
+    t =    12.87s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.91s     Find the "Delete" Button
+    t =    12.92s         Snapshot accessibility hierarchy for app with pid 39907
+    t =    12.94s         Find: Descendants matching type Table
+    t =    12.94s         Find: Descendants matching type Button
+    t =    12.94s         Find: Elements matching predicate '"Delete" IN identifiers'
+    t =    13.05s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    14.10s         Find the "Delete" Button (retry 1)
+    t =    14.10s             Snapshot accessibility hierarchy for app with pid 39907
+    t =    14.12s             Find: Descendants matching type Table
+    t =    14.13s             Find: Descendants matching type Button
+    t =    14.13s             Find: Elements matching predicate '"Delete" IN identifiers'
+    t =    14.23s             Wait for net.hoge2.XCUITests-Example to idle
+    t =    15.28s         Find the "Delete" Button (retry 2)
+    t =    15.29s             Snapshot accessibility hierarchy for app with pid 39907
+    t =    15.31s             Find: Descendants matching type Table
+    t =    15.31s             Find: Descendants matching type Button
+    t =    15.31s             Find: Elements matching predicate '"Delete" IN identifiers'
+    t =    15.42s             Wait for net.hoge2.XCUITests-Example to idle
+** TEST FAILED **
+    t =    15.56s Tear Down
+Test Case '-[XCUITests_ExampleUITestsFail testExample]' failed (15.769 seconds).
+    t =    15.52s         Assertion Failure: XCUITests_ExampleUITestsFail.m:57: No matches found for Find: Elements matching predicate '"Delete" IN identifiers' from input {(
+Test Suite 'XCUITests_ExampleUITestsFail' failed at 2018-05-17 07:08:09.782.
+Test Suite 'XCUITests_SubUITests' started at 2018-05-17 07:08:09.783
+Test Case '-[XCUITests_SubUITests testExample]' started.
+    t =     0.00s Start Test at 2018-05-17 07:08:09.784
+    t =     0.04s Set Up
+    t =     0.14s     Open net.hoge2.XCUITests-Example
+    t =     0.18s         Launch net.hoge2.XCUITests-Example
+    t =     0.18s             Terminate net.hoge2.XCUITests-Example:39907
+    t =     5.27s             Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.46s Tap "Add" Button
+    t =     6.46s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.51s     Find the "Add" Button
+    t =     6.51s         Snapshot accessibility hierarchy for app with pid 39915
+    t =     6.55s         Find: Descendants matching type NavigationBar
+    t =     6.55s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     6.55s         Find: Descendants matching type Button
+    t =     6.56s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     6.66s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     6.71s     Synthesize event
+    t =     6.85s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.33s Tap "Add" Button
+    t =     7.33s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.39s     Find the "Add" Button
+    t =     7.39s         Snapshot accessibility hierarchy for app with pid 39915
+    t =     7.42s         Find: Descendants matching type NavigationBar
+    t =     7.42s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     7.42s         Find: Descendants matching type Button
+    t =     7.42s         Find: Elements matching predicate '"Add" IN identifiers'
+    t =     7.53s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     7.57s     Synthesize event
+    t =     7.69s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.17s Tap Cell
+    t =     8.17s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.22s     Find the Cell
+    t =     8.22s         Snapshot accessibility hierarchy for app with pid 39915
+    t =     8.24s         Find: Descendants matching type Table
+    t =     8.24s         Find: Descendants matching type Cell
+    t =     8.24s         Find: Element at index 0
+    t =     8.35s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     8.40s     Synthesize event
+    t =     8.52s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.06s Tap "Master" Button
+    t =     9.06s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.12s     Find the "Master" Button
+    t =     9.12s         Snapshot accessibility hierarchy for app with pid 39915
+    t =     9.15s         Find: Descendants matching type NavigationBar
+    t =     9.15s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =     9.15s         Find: Descendants matching type Button
+    t =     9.15s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =     9.26s         Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.31s     Synthesize event
+    t =     9.44s     Wait for net.hoge2.XCUITests-Example to idle
+    t =     9.95s Tap Cell
+    t =     9.95s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.01s     Find the Cell
+    t =    10.01s         Snapshot accessibility hierarchy for app with pid 39915
+    t =    10.03s         Find: Descendants matching type Table
+    t =    10.04s         Find: Descendants matching type Cell
+    t =    10.04s         Find: Element at index 1
+    t =    10.14s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.20s     Synthesize event
+    t =    10.33s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.85s Tap "Master" Button
+    t =    10.85s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    10.90s     Find the "Master" Button
+    t =    10.90s         Snapshot accessibility hierarchy for app with pid 39915
+    t =    10.92s         Find: Descendants matching type NavigationBar
+    t =    10.93s         Find: Elements matching predicate '"Detail" IN identifiers'
+    t =    10.93s         Find: Descendants matching type Button
+    t =    10.93s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    11.04s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.09s     Synthesize event
+    t =    11.21s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.72s Tap "Edit" Button
+    t =    11.72s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.78s     Find the "Edit" Button
+    t =    11.78s         Snapshot accessibility hierarchy for app with pid 39915
+    t =    11.81s         Find: Descendants matching type NavigationBar
+    t =    11.81s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    11.81s         Find: Descendants matching type Button
+    t =    11.81s         Find: Elements matching predicate '"Edit" IN identifiers'
+    t =    11.91s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    11.96s     Synthesize event
+    t =    12.08s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.56s Tap "Done" Button
+    t =    12.56s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.62s     Find the "Done" Button
+    t =    12.62s         Snapshot accessibility hierarchy for app with pid 39915
+    t =    12.65s         Find: Descendants matching type NavigationBar
+    t =    12.65s         Find: Elements matching predicate '"Master" IN identifiers'
+    t =    12.65s         Find: Descendants matching type Button
+    t =    12.65s         Find: Elements matching predicate '"Done" IN identifiers'
+    t =    12.76s         Wait for net.hoge2.XCUITests-Example to idle
+    t =    12.81s     Synthesize event
+    t =    12.93s     Wait for net.hoge2.XCUITests-Example to idle
+    t =    13.41s Tear Down
+Test Case '-[XCUITests_SubUITests testExample]' passed (13.610 seconds).
+Test Suite 'XCUITests-ExampleUITests.xctest' failed at 2018-05-17 07:08:23.395.
+Test Suite 'XCUITests_SubUITests' passed at 2018-05-17 07:08:23.394.
+    t =    15.52s         Assertion Failure: XCUITests_ExampleUITestsFail.m:57: No matches found for Find: Elements matching predicate '"Delete" IN identifiers' from input {(
+Test Suite 'All tests' failed at 2018-05-17 07:08:23.396.


### PR DESCRIPTION
Fixed a bug in XCodeBuildOutputParser based on @ bgalamb's report and fixes.
This is mainly related to JENKIS JIRA report [JENKINS-37072](https://issues.jenkins-ci.org/browse/JENKINS-37072), which occurs when test results from xcodebuild are output out of order at test execution.
In this revision, we took the effort to restore the output of the broken order as much as possible.

Also Fix not to use timestamp for log file name. (Use "xcodebuild.log" as a fixed file name)
Because using a timestamp as a filename, No way to know it with shell script etc.
And Remove buildDirectory.exists() && buildDirectory.isDirectory() from condition for createing Logfile output directory.
Because If Generate archive is not specified, directory was not created.