### PR TITLE
Improved affinity for Pipeline by using @DataBoundSetter instead of @…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
       <name>Jerome Lacoste</name>
       <email>jerome.lacoste@gmail.com</email>
     </developer>
+    <developer>
+      <id>kazuhidet</id>
+      <name>Kazuhide Takahashi</name>
+      <email>kazuhide.t@linux-powered.com</email>
+    </developer>
   </developers>
   <scm>
     <connection>scm:git:git@github.com:jenkinsci/xcode-plugin.git</connection>
@@ -95,11 +100,6 @@
       <artifactId>workflow-cps</artifactId>
       <version>2.0</version>
       <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.plist</groupId>
-      <artifactId>dd-plist</artifactId>
-      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.plist</groupId>

--- a/src/main/java/au/com/rayh/ExportIpa.java
+++ b/src/main/java/au/com/rayh/ExportIpa.java
@@ -11,9 +11,11 @@ import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.inject.Inject;
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,54 +24,326 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ExportIpa extends Builder implements SimpleBuildStep {
-    public final Boolean buildIpa;
-    public final Boolean generateArchive;
-    public final Boolean noConsoleLog;
-    public final String logfileOutputDirectory;
-    public final Boolean cleanBeforeBuild;
-    public final Boolean cleanTestReports;
-    public final String configuration;
-    public final String target;
-    public final String sdk;
-    public final String xcodeProjectPath;
-    public final String xcodeProjectFile;
-    public final String xcodebuildArguments;
-    public final String cfBundleVersionValue;
-    public final String cfBundleShortVersionStringValue;
-    public final Boolean unlockKeychain;
-    public final String keychainName;
-    public final String keychainPath;
-    public final String keychainPwd;
-    public final String symRoot;
-    public final String xcodeWorkspaceFile;
-    public final String xcodeSchema;
-    public final String archiveDir;
-    public final String developmentTeamName;
-    public final String developmentTeamID;
-    public final Boolean allowFailingBuildResults;
-    public final String ipaName;
-    public final Boolean provideApplicationVersion;
-    public final String ipaOutputDirectory;
-    public final Boolean changeBundleID;
-    public final String bundleID;
-    public final String bundleIDInfoPlistPath;
-    public final Boolean interpretTargetAsRegEx;
-    public final String ipaExportMethod;
-    public final Boolean manualSigning;
-    public final ArrayList<ProvisioningProfile> provisioningProfiles;
-    public final String xcodeName;
-    public final Boolean uploadBitcode;
-    public final Boolean uploadSymbols;
-    public final Boolean compileBitcode;
-    public final String thinning;
-    public final Boolean packResourcesAsset;
-    public final String resourcesAssetURL;
-    public final String appURL;
-    public final String displayImageURL;
-    public final String fullSizeImageURL;
-    public final String assetPackManifestURL;
+    @CheckForNull
+    private String xcodeProjectPath;
+    @CheckForNull
+    private String xcodeProjectFile;
+    private Boolean unlockKeychain;
+    @CheckForNull
+    private String keychainName;
+    @CheckForNull
+    private String keychainPath;
+    @CheckForNull
+    private String keychainPwd;
+    @CheckForNull
+    private String symRoot;
+    @CheckForNull
+    private String xcodeWorkspaceFile;
+    @CheckForNull
+    private String xcodeSchema;
+    @CheckForNull
+    private String archiveDir;
+    @CheckForNull
+    private String developmentTeamName;
+    @CheckForNull
+    private String developmentTeamID;
+    @CheckForNull
+    private String ipaName;
+    @CheckForNull
+    private String ipaOutputDirectory;
+    @CheckForNull
+    private String ipaExportMethod;
+    private Boolean manualSigning;
+    @CheckForNull
+    private ArrayList<ProvisioningProfile> provisioningProfiles;
+    @CheckForNull
+    private String xcodeName;
+    private Boolean uploadBitcode;
+    private Boolean uploadSymbols;
+    private Boolean compileBitcode;
+    @CheckForNull
+    private String thinning;
+    private Boolean embedOnDemandResourcesAssetPacksInBundle;
+    @CheckForNull
+    private String onDemandResourcesAssetPacksBaseURL;
+    @CheckForNull
+    private String appURL;
+    @CheckForNull
+    private String displayImageURL;
+    @CheckForNull
+    private String fullSizeImageURL;
+    @CheckForNull
+    private String assetPackManifestURL;
+
+    @CheckForNull
+    public String getXcodeProjectPath() {
+	return xcodeProjectPath;
+    }
+
+    @DataBoundSetter
+    public void setXcodeProjectPath(String xcodeProjectPath) {
+	this.xcodeProjectPath = xcodeProjectPath;
+    }
+
+    @CheckForNull
+    public String getXcodeProjectFile() {
+	return xcodeProjectFile;
+    }
+
+    public Boolean getUnlockKeychain() {
+	return unlockKeychain;
+    }
+
+    @DataBoundSetter
+    public void setUnlockKeychain(Boolean unlockKeychain) {
+	this.unlockKeychain = unlockKeychain;
+    }
+
+    @CheckForNull
+    public String getKeychainName() {
+	return keychainName;
+    }
+
+    @DataBoundSetter
+    public void setKeychainName(String keychainName) {
+	this.keychainName = keychainName;
+    }
+
+    @CheckForNull
+    public String getKeychainPath() {
+	return keychainPath;
+    }
+
+    @DataBoundSetter
+    public void setKeychainPath(String keychainPath) {
+	this.keychainPath = keychainPath;
+    }
+
+    @CheckForNull
+    public String getKeychainPwd() {
+	return keychainPwd;
+    }
+
+    @DataBoundSetter
+    public void setKeychainPwd(String keychainPwd) {
+	this.keychainPwd = keychainPwd;
+    }
+
+    @CheckForNull
+    public String getSymRoot() {
+	return symRoot;
+    }
+
+    @DataBoundSetter
+    public void setSymRoot(String symRoot) {
+	this.symRoot = symRoot;
+    }
+
+    @CheckForNull
+    public String getXcodeWorkspaceFile() {
+	return xcodeWorkspaceFile;
+    }
+
+    @DataBoundSetter
+    public void setXcodeWorkspaceFile(String xcodeWorkspaceFile) {
+	this.xcodeWorkspaceFile = xcodeWorkspaceFile;
+    }
+
+    @CheckForNull
+    public String getXcodeSchema() {
+	return xcodeSchema;
+    }
+
+    @DataBoundSetter
+    public void setXcodeSchema(String xcodeSchema) {
+	this.xcodeSchema = xcodeSchema;
+    }
+
+    @CheckForNull
+    public String getArchiveDir() {
+	return archiveDir;
+    }
+
+    @DataBoundSetter
+    public void setArchiveDir(String archiveDir) {
+	this.archiveDir = archiveDir;
+    }
+
+    @CheckForNull
+    public String getDevelopmentTeamName() {
+	return developmentTeamName;
+    }
+
+    @DataBoundSetter
+    public void setDevelopmentTeamName(String developmentTeamName) {
+	this.developmentTeamName = developmentTeamName;
+    }
+
+    @CheckForNull
+    public String getDevelopmentTeamID() {
+	return developmentTeamID;
+    }
+
+    @DataBoundSetter
+    public void setDevelopmentTeamID(String developmentTeamID) {
+	this.developmentTeamID = developmentTeamID;
+    }
+
+    @CheckForNull
+    public String getIpaName() {
+	return ipaName;
+    }
+
+    @DataBoundSetter
+    public void setIpaName(String ipaName) {
+	this.ipaName = ipaName;
+    }
+
+    @CheckForNull
+    public String getIpaOutputDirectory() {
+	return ipaOutputDirectory;
+    }
+
+    @DataBoundSetter
+    public void setIpaOutputDirectory(String ipaOutputDirectory) {
+	this.ipaOutputDirectory = ipaOutputDirectory;
+    }
+
+    @CheckForNull
+    public String getIpaExportMethod() {
+	return ipaExportMethod;
+    }
+
+    @DataBoundSetter
+    public void setIpaExportMethod(String ipaExportMethod) {
+	this.ipaExportMethod = ipaExportMethod;
+    }
+
+    public Boolean getManualSigning() {
+	return  manualSigning;
+    }
+
+    @DataBoundSetter
+    public void setManualSigning(Boolean manualSigning) {
+	this.manualSigning = manualSigning;
+    }
+
+    @CheckForNull
+    public ArrayList<ProvisioningProfile> getProvisioningProfiles() {
+	return provisioningProfiles;
+    }
+
+    @DataBoundSetter
+    public void setProvisioningProfiles(ArrayList<ProvisioningProfile> provisioningProfiles) {
+	this.provisioningProfiles = provisioningProfiles;
+    }
+
+    @CheckForNull
+    public String getXcodeName() {
+	return xcodeName;
+    }
+
+    @DataBoundSetter
+    public void setXcodeName(String xcodeName) {
+	this.xcodeName = xcodeName;
+    }
+
+    public Boolean getUploadBitcode() {
+	return uploadBitcode;
+    }
+
+    @DataBoundSetter
+    public void setUploadBitcode(Boolean uploadBitcode) {
+	this.uploadBitcode = uploadBitcode;
+    }
+
+    public Boolean getUploadSymbols() {
+	return uploadSymbols;
+    }
+
+    @DataBoundSetter
+    public void setUploadSymbols(Boolean uploadSymbols) {
+	this.uploadSymbols = uploadSymbols;
+    }
+
+    public Boolean getCompileBitcode() {
+	return compileBitcode;
+    }
+
+    @DataBoundSetter
+    public void setCompileBitcode(Boolean compileBitcode) {
+	this.compileBitcode = compileBitcode;
+    }
+
+    @CheckForNull
+    public String getThinning() {
+	return thinning;
+    }
+
+    @DataBoundSetter
+    public void setThinning(String thinning) {
+	this.thinning = thinning;
+    }
+
+    public Boolean getPackResourcesAsset() {
+	return embedOnDemandResourcesAssetPacksInBundle;
+    }
+
+    @DataBoundSetter
+    public void setPackResourcesAsset(Boolean packResourcesAsset) {
+	this.embedOnDemandResourcesAssetPacksInBundle = packResourcesAsset;
+    }
+
+    @CheckForNull
+    public String getResourcesAssetURL() {
+	return onDemandResourcesAssetPacksBaseURL;
+    }
+
+    @DataBoundSetter
+    public void setResourcesAssetURL(String resourcesAssetURL) {
+	this.onDemandResourcesAssetPacksBaseURL = resourcesAssetURL;
+    }
+
+    @CheckForNull
+    public String getAppURL() {
+	return appURL;
+    }
+
+    @DataBoundSetter
+    public void setAppURL(String appURL) {
+	this.appURL = appURL;
+    }
+
+    @CheckForNull
+    public String getDisplayImageURL() {
+	return displayImageURL;
+    }
+
+    @DataBoundSetter
+    public void setDisplayImageURL(String displayImageURL) {
+	this.displayImageURL = displayImageURL;
+    }
+
+    @CheckForNull
+    public String getFullSizeImageURL() {
+	return fullSizeImageURL;
+    }
+
+    @DataBoundSetter
+    public void setFullSizeImageURL(String fullSizeImageURL) {
+	this.fullSizeImageURL = fullSizeImageURL;
+    }
+
+    @CheckForNull
+    public String getAssetPackManifestURL() {
+	return assetPackManifestURL;
+    }
 
     @DataBoundConstructor
+    public ExportIpa() {
+    }
+
+    @Deprecated
     public ExportIpa(String xcodeProjectPath, String xcodeProjectFile,
                 Boolean unlockKeychain, String keychainName, String keychainPath, String keychainPwd, String symRoot, String xcodeWorkspaceFile,
                 String xcodeSchema, String archiveDir, String developmentTeamName, String developmentTeamID,
@@ -80,38 +354,21 @@ public class ExportIpa extends Builder implements SimpleBuildStep {
 		Boolean packResourcesAsset, String resourcesAssetURL,
 		String appURL, String displayImageURL, String fullSizeImageURL,
 		String assetPackManifestURL) {
-        this.buildIpa = true;
-        this.generateArchive = false;
-        this.noConsoleLog = true;
-        this.logfileOutputDirectory = null;
-        this.sdk = null;
-        this.target = null;
-        this.cleanBeforeBuild = false;
-        this.cleanTestReports = false;
-        this.configuration = null;
+	this();
         this.xcodeProjectPath = xcodeProjectPath;
         this.xcodeProjectFile = xcodeProjectFile;
-        this.xcodebuildArguments = null;
         this.keychainName = keychainName;
         this.xcodeWorkspaceFile = xcodeWorkspaceFile;
         this.xcodeSchema = xcodeSchema;
         this.developmentTeamName = developmentTeamName;
         this.developmentTeamID = developmentTeamID;
-        this.cfBundleVersionValue = null;
-        this.cfBundleShortVersionStringValue = null;
         this.unlockKeychain = unlockKeychain;
         this.keychainPath = keychainPath;
         this.keychainPwd = keychainPwd;
         this.symRoot = symRoot;
         this.archiveDir = archiveDir;
-        this.allowFailingBuildResults = false;
         this.ipaName = ipaName;
         this.ipaOutputDirectory = ipaOutputDirectory;
-        this.provideApplicationVersion = false;
-        this.changeBundleID = false;
-        this.bundleID = null;
-        this.bundleIDInfoPlistPath = null;
-        this.interpretTargetAsRegEx = false;
         this.ipaExportMethod = ipaExportMethod;
         this.manualSigning = manualSigning;
         this.provisioningProfiles = provisioningProfiles;
@@ -120,8 +377,8 @@ public class ExportIpa extends Builder implements SimpleBuildStep {
         this.uploadSymbols = uploadSymbols;
         this.compileBitcode = compileBitcode;
         this.thinning = thinning;
-        this.packResourcesAsset = packResourcesAsset;
-        this.resourcesAssetURL = resourcesAssetURL;
+        this.embedOnDemandResourcesAssetPacksInBundle = packResourcesAsset;
+        this.onDemandResourcesAssetPacksBaseURL = resourcesAssetURL;
         this.appURL = appURL;
         this.displayImageURL = displayImageURL;
         this.fullSizeImageURL = fullSizeImageURL;
@@ -135,15 +392,15 @@ public class ExportIpa extends Builder implements SimpleBuildStep {
 
     @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private boolean _perform(Run<?,?> build, FilePath filePath, Launcher launcher, EnvVars envs, TaskListener listener) throws InterruptedException, IOException {
-	XCodeBuilder builder = new XCodeBuilder(buildIpa, generateArchive, noConsoleLog, logfileOutputDirectory, cleanBeforeBuild, cleanTestReports, configuration,
-                target, sdk, xcodeProjectPath, xcodeProjectFile, xcodebuildArguments,
-                cfBundleVersionValue, cfBundleShortVersionStringValue, unlockKeychain,
+	XCodeBuilder builder = new XCodeBuilder(true, false, true, null, false, false, null,
+                null, null, xcodeProjectPath, xcodeProjectFile, null,
+                null, null, unlockKeychain,
                 keychainName, keychainPath, keychainPwd, symRoot, xcodeWorkspaceFile,
-                xcodeSchema, archiveDir, developmentTeamName, developmentTeamID, allowFailingBuildResults,
-                ipaName, provideApplicationVersion, ipaOutputDirectory, changeBundleID, bundleID,
-                bundleIDInfoPlistPath, interpretTargetAsRegEx, ipaExportMethod, manualSigning, provisioningProfiles, xcodeName,
+                xcodeSchema, archiveDir, developmentTeamName, developmentTeamID, false,
+                ipaName, false, ipaOutputDirectory, false, null,
+                null, false, ipaExportMethod, manualSigning, provisioningProfiles, xcodeName,
 		uploadBitcode, uploadSymbols, compileBitcode, thinning,
-		packResourcesAsset, resourcesAssetURL,
+		embedOnDemandResourcesAssetPacksInBundle, onDemandResourcesAssetPacksBaseURL,
 		appURL, displayImageURL, fullSizeImageURL, assetPackManifestURL);
 		
 	builder.setSkipBuildStep(true);

--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -51,10 +51,12 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import jenkins.model.Jenkins;
 
 import javax.inject.Inject;
+import javax.annotation.CheckForNull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -92,197 +94,668 @@ public class XCodeBuilder extends Builder implements SimpleBuildStep {
     /**
      * @since 1.0
      */
-    public final Boolean cleanBeforeBuild;
+    private Boolean cleanBeforeBuild;
     /**
      * @since 1.3
      */
-    public final Boolean cleanTestReports;
+    private Boolean cleanTestReports;
     /**
      * @since 1.0
      */
-    public final String configuration;
+    @CheckForNull
+    private String configuration;
     /**
      * @since 1.0
      */
-    public final String target;
+    @CheckForNull
+    private String target;
     /**
      * @since 1.0
      */
-    public final String sdk;
+    @CheckForNull
+    private String sdk;
     /**
      * @since 1.1
      */
-    public final String symRoot;
+    @CheckForNull
+    private String symRoot;
     /**
      * @since 1.2
      */
-    public final String buildDir;
+    @CheckForNull
+    private String buildDir;
     /**
      * @since 1.0
      */
-    public final String xcodeProjectPath;
+    @CheckForNull
+    private String xcodeProjectPath;
     /**
      * @since 1.0
      */
-    public final String xcodeProjectFile;
+    @CheckForNull
+    private String xcodeProjectFile;
     /**
      * @since 1.3
      */
-    public final String xcodebuildArguments;
+    @CheckForNull
+    private String xcodebuildArguments;
     /**
      * @since 1.2
      */
-    public final String xcodeSchema;
+    @CheckForNull
+    private String xcodeSchema;
     /**
      * @since 1.2
      */
-    public final String xcodeWorkspaceFile;
+    @CheckForNull
+    private String xcodeWorkspaceFile;
     /**
      * @since 1.0
      */
-    public final String cfBundleVersionValue;
+    @CheckForNull
+    private String cfBundleVersionValue;
     /**
      * @since 1.0
      */
-    public final String cfBundleShortVersionStringValue;
+    @CheckForNull
+    private String cfBundleShortVersionStringValue;
     /**
      * @since 1.0
      */
-    public final Boolean buildIpa;
+    private Boolean buildIpa;
     /**
      * @since 1.4.12
      */
-    public final String ipaExportMethod;
+    @CheckForNull
+    private String ipaExportMethod;
     /**
      * @since 1.0
      */
-    public final Boolean generateArchive;
+    private Boolean generateArchive;
     /**
      * @since 2.0.1
      */
-    public final Boolean noConsoleLog;
+    private Boolean noConsoleLog;
     /**
      * @since 2.0.1
      */
-    public final String logfileOutputDirectory;
+    @CheckForNull
+    private String logfileOutputDirectory;
     /**
      * @since 1.5
      **/
-    public final Boolean unlockKeychain;
+    private Boolean unlockKeychain;
     /**
      * @since 1.4
      */
-    public final String keychainName;
+    @CheckForNull
+    private String keychainName;
     /**
      * @since 1.0
      */
-    public final String keychainPath;
+    @CheckForNull
+    private String keychainPath;
     /**
      * @since 1.0
      */
-    public final String keychainPwd;
+    @CheckForNull
+    private String keychainPwd;
     /**
      * @since 1.4.12
      */
-    public final String developmentTeamName;
+    @CheckForNull
+    private String developmentTeamName;
     /**
      * @since 1.4.12
      */
-    public final String developmentTeamID;
+    @CheckForNull
+    private String developmentTeamID;
     /**
      * @since 1.4
      */
-    public final Boolean allowFailingBuildResults;
+    private Boolean allowFailingBuildResults;
     /**
      * @since 1.4
      */
-    public final String ipaName;
+    @CheckForNull
+    private String ipaName;
     /**
      * @since 1.4
      */
-    public final String ipaOutputDirectory;
+    @CheckForNull
+    private String ipaOutputDirectory;
     /**
      * @since 1.4
      */
-    public Boolean provideApplicationVersion;
+    private Boolean provideApplicationVersion;
     /**
      * @since 1.4
      */
-    public final Boolean changeBundleID;
+    private Boolean changeBundleID;
     /**
      * @since 1.4
      */
-    public final String bundleID;
+    @CheckForNull
+    private String bundleID;
     /**
      * @since 1.4
      */
-    public final String bundleIDInfoPlistPath;
+    @CheckForNull
+    private String bundleIDInfoPlistPath;
     /**
      * @since 1.4
      */
-    public final Boolean interpretTargetAsRegEx;
+    private Boolean interpretTargetAsRegEx;
     /**
      * @deprecated 2.0.3
      *
-    public final String ipaManifestPlistUrl;
+    @CheckForNull
+    private String ipaManifestPlistUrl;
      */
     /**
      * @since 2.0.1
      */
-    public final Boolean manualSigning;
+    private Boolean manualSigning;
     /**
      * @since 2.0.1
      */
-    public ArrayList<ProvisioningProfile> provisioningProfiles = new ArrayList<>();
+    @CheckForNull
+    private ArrayList<ProvisioningProfile> provisioningProfiles = new ArrayList<>();
     /*
      * @since 2.0.3
      */
-    public final String xcodeName;
+    @CheckForNull
+    private String xcodeName;
     /*
      * @since 2.0.3
      */
-    public final Boolean uploadBitcode;
+    private Boolean uploadBitcode;
     /*
      * @since 2.0.3
      */
-    public final Boolean uploadSymbols;
+    private Boolean uploadSymbols;
     /*
      * @since 2.0.3
      */
-    public final Boolean compileBitcode;
+    private Boolean compileBitcode;
     /*
      * @since 2.0.3
      */
-    public final String thinning;
+    @CheckForNull
+    private String thinning;
     /*
      * @since 2.0.3
      */
-    public final Boolean embedOnDemandResourcesAssetPacksInBundle;
+    private Boolean embedOnDemandResourcesAssetPacksInBundle;
     /*
      * @since 2.0.3
      */
-    public final String onDemandResourcesAssetPacksBaseURL;
+    @CheckForNull
+    private String onDemandResourcesAssetPacksBaseURL;
     /*
      * @since 2.0.3
      */
-    public final String appURL;
+    @CheckForNull
+    private String appURL;
     /*
      * @since 2.0.3
      */
-    public final String displayImageURL;
+    @CheckForNull
+    private String displayImageURL;
     /*
      * @since 2.0.3
      */
-    public final String fullSizeImageURL;
+    @CheckForNull
+    private String fullSizeImageURL;
     /*
      * @since 2.0.3
      */
-    public final String assetPackManifestURL;
+    @CheckForNull
+    private String assetPackManifestURL;
+    /**
+     * @since 2.0.3
+     */
+    private Boolean skipBuildStep;
 
-    /**
-     * @since 2.0.3
-     */
-    Boolean skipBuildStep;
+    public Boolean getCleanBeforeBuild() {
+	return cleanBeforeBuild;
+    }
+
+    @DataBoundSetter
+    public void setCleanBeforeBuild(Boolean cleanBeforeBuild) {
+	this.cleanBeforeBuild = cleanBeforeBuild;
+    }
+
+    public Boolean getCleanTestReports() {
+	return cleanTestReports;
+    }
+
+    @DataBoundSetter
+    public void setCleanTestReports(Boolean cleanTestReports) {
+	this.cleanTestReports = cleanTestReports;
+    }
+
+    @CheckForNull
+    public String getConfiguration() {
+	return configuration;
+    }
+
+    @DataBoundSetter
+    public void setConfiguration(String configuration) {
+	this.configuration = configuration;
+    }
+
+    @CheckForNull
+    public String getTarget() {
+	return target;
+    }
+
+    @DataBoundSetter
+    public void setTarget(String target) {
+	this.target = target;
+    }
+
+    @CheckForNull
+    public String getSdk() {
+	return sdk;
+    }
+
+    @DataBoundSetter
+    public void setSdk(String sdk) {
+	this.sdk = sdk;
+    }
+
+    @CheckForNull
+    public String getSymRoot() {
+	return symRoot;
+    }
+
+    @DataBoundSetter
+    public void setSymRoot(String symRoot) {
+	this.symRoot = symRoot;
+    }
+
+    @CheckForNull
+    public String getBuildDir() {
+	return buildDir;
+    }
+
+    @DataBoundSetter
+    public void setBuildDir(String buildDir) {
+	this.buildDir = buildDir;
+    }
+
+    @CheckForNull
+    public String getXcodeProjectPath() {
+	return xcodeProjectPath;
+    }
+
+    @DataBoundSetter
+    public void setXcodeProjectPath(String xcodeProjectPath) {
+	this.xcodeProjectPath = xcodeProjectPath;
+    }
+
+    @CheckForNull
+    public String getXcodeProjectFile() {
+	return xcodeProjectFile;
+    }
+
+    @DataBoundSetter
+    public void setXcodeProjectFile(String xcodeProjectFile) {
+	this.xcodeProjectFile = xcodeProjectFile;
+    }
+
+    @CheckForNull
+    public String getXcodebuildArguments() {
+	return xcodebuildArguments;
+    }
+
+    @DataBoundSetter
+    public void setXcodebuildArguments(String xcodebuildArguments) {
+	this.xcodebuildArguments = xcodebuildArguments;
+    }
+
+    @CheckForNull
+    public String getXcodeSchema() {
+	return xcodeSchema;
+    }
+
+    @DataBoundSetter
+    public void setXcodeSchema(String xcodeSchema) {
+	this.xcodeSchema = xcodeSchema;
+    }
+
+    @CheckForNull
+    public String getXcodeWorkspaceFile() {
+	return xcodeWorkspaceFile;
+    }
+
+    @DataBoundSetter
+    public void setXcodeWorkspaceFile(String xcodeWorkspaceFile) {
+	this.xcodeWorkspaceFile = xcodeWorkspaceFile;
+    }
+
+    @CheckForNull
+    public String getCfBundleVersionValue() {
+	return cfBundleVersionValue;
+    }
+
+    @DataBoundSetter
+    public void setCfBundleVersionValue(String cfBundleVersionValue) {
+	this.cfBundleVersionValue = cfBundleVersionValue;
+    }
+
+    @CheckForNull
+    public String getCfBundleShortVersionStringValue() {
+	return cfBundleShortVersionStringValue;
+    }
+
+    @DataBoundSetter
+    public void setCfBundleShortVersionStringValue(String cfBundleShortVersionStringValue) {
+	this.cfBundleShortVersionStringValue = cfBundleShortVersionStringValue;
+    }
+
+    public Boolean getBuildIpa() {
+	return buildIpa;
+    }
+
+    @DataBoundSetter
+    public void setBuildIpa(Boolean buildIpa) {
+	this.buildIpa = buildIpa;
+    }
+
+    @CheckForNull
+    public String getIpaExportMethod() {
+	return ipaExportMethod;
+    }
+
+    @DataBoundSetter
+    public void setIpaExportMethod(String ipaExportMethod) {
+	this.ipaExportMethod = ipaExportMethod;
+    }
+
+    public Boolean getGenerateArchive() {
+	return generateArchive;
+    }
+
+    @DataBoundSetter
+    public void setGenerateArchive(Boolean generateArchive) {
+	this.generateArchive = generateArchive;
+    }
+
+    public Boolean getNoConsoleLog() {
+	return noConsoleLog;
+    }
+
+    @DataBoundSetter
+    public void setNoConsoleLog(Boolean noConsoleLog) {
+	this.noConsoleLog = noConsoleLog;
+    }
+
+    @CheckForNull
+    public String getLogfileOutputDirectory() {
+	return logfileOutputDirectory;
+    }
+
+    @DataBoundSetter
+    public void setLogfileOutputDirectory(String logfileOutputDirectory) {
+	this.logfileOutputDirectory = logfileOutputDirectory;
+    }
+
+    public Boolean getUnlockKeychain() {
+	return unlockKeychain;
+    }
+
+    @DataBoundSetter
+    public void setUnlockKeychain(Boolean unlockKeychain) {
+	this.unlockKeychain = unlockKeychain;
+    }
+
+    @CheckForNull
+    public String getKeychainName() {
+	return keychainName;
+    }
+
+    @DataBoundSetter
+    public void setKeychainName(String keychainName) {
+	this.keychainName = keychainName;
+    }
+
+    @CheckForNull
+    public String getKeychainPath() {
+	return keychainPath;
+    }
+
+    @DataBoundSetter
+    public void setKeychainPath(String keychainPath) {
+	this.keychainPath = keychainPath;
+    }
+
+    @CheckForNull
+    public String getKeychainPwd() {
+	return keychainPwd;
+    }
+
+    @DataBoundSetter
+    public void setKeychainPwd(String keychainPwd) {
+	this.keychainPwd = keychainPwd;
+    }
+
+    @CheckForNull
+    public String getDevelopmentTeamName() {
+	return developmentTeamName;
+    }
+
+    @DataBoundSetter
+    public void setDevelopmentTeamName(String developmentTeamName) {
+	this.developmentTeamName = developmentTeamName;
+    }
+
+    @CheckForNull
+    public String getDevelopmentTeamID() {
+	return developmentTeamID;
+    }
+
+    @DataBoundSetter
+    public void setDevelopmentTeamID(String developmentTeamID) {
+	this.developmentTeamID = developmentTeamID;
+    }
+
+    public Boolean getAllowFailingBuildResults() {
+	return allowFailingBuildResults;
+    }
+
+    @DataBoundSetter
+    public void setAllowFailingBuildResults(Boolean allowFailingBuildResults) {
+	this.allowFailingBuildResults = allowFailingBuildResults;
+    }
+
+    @CheckForNull
+    public String getIpaName() {
+	return ipaName;
+    }
+
+    @DataBoundSetter
+    public void setIpaName(String ipaName) {
+	this.ipaName = ipaName;
+    }
+
+    @CheckForNull
+    public String getIpaOutputDirectory() {
+	return ipaOutputDirectory;
+    }
+
+    @DataBoundSetter
+    public void setIpaOutputDirectory(String ipaOutputDirectory) {
+	this.ipaOutputDirectory = ipaOutputDirectory;
+    }
+
+    public Boolean getProvideApplicationVersion() {
+	return provideApplicationVersion;
+    }
+
+    @DataBoundSetter
+    public void setProvideApplicationVersion(Boolean provideApplicationVersion) {
+	this.provideApplicationVersion = provideApplicationVersion;
+    }
+
+    public Boolean getChangeBundleID() {
+	return changeBundleID;
+    }
+
+    @DataBoundSetter
+    public void setChangeBundleID(Boolean changeBundleID) {
+	this.changeBundleID = changeBundleID;
+    }
+
+    @CheckForNull
+    public String getBundleID() {
+	return bundleID;
+    }
+
+    @DataBoundSetter
+    public void setBundleID(String bundleID) {
+	this.bundleID = bundleID;
+    }
+
+    @CheckForNull
+    public String getBundleIDInfoPlistPath() {
+	return bundleIDInfoPlistPath;
+    }
+
+    @DataBoundSetter
+    public void setBundleIDInfoPlistPath(String bundleIDInfoPlistPath) {
+	this.bundleIDInfoPlistPath = bundleIDInfoPlistPath;
+    }
+
+    public Boolean getInterpretTargetAsRegEx() {
+	return interpretTargetAsRegEx;
+    }
+
+    @DataBoundSetter
+    public void setInterpretTargetAsRegEx(Boolean interpretTargetAsRegEx) {
+	this.interpretTargetAsRegEx = interpretTargetAsRegEx;
+    }
+
+    public Boolean getManualSigning() {
+	return  manualSigning;
+    }
+
+    @DataBoundSetter
+    public void setManualSigning(Boolean manualSigning) {
+	this.manualSigning = manualSigning;
+    }
+
+    @CheckForNull
+    public ArrayList<ProvisioningProfile> getProvisioningProfiles() {
+	return provisioningProfiles;
+    }
+
+    @DataBoundSetter
+    public void setProvisioningProfiles(ArrayList<ProvisioningProfile> provisioningProfiles) {
+	this.provisioningProfiles = provisioningProfiles;
+    }
+
+    @CheckForNull
+    public String getXcodeName() {
+	return xcodeName;
+    }
+
+    @DataBoundSetter
+    public void setXcodeName(String xcodeName) {
+	this.xcodeName = xcodeName;
+    }
+
+    public Boolean getUploadBitcode() {
+	return uploadBitcode;
+    }
+
+    @DataBoundSetter
+    public void setUploadBitcode(Boolean uploadBitcode) {
+	this.uploadBitcode = uploadBitcode;
+    }
+
+    public Boolean getUploadSymbols() {
+	return uploadSymbols;
+    }
+
+    @DataBoundSetter
+    public void setUploadSymbols(Boolean uploadSymbols) {
+	this.uploadSymbols = uploadSymbols;
+    }
+
+    public Boolean getCompileBitcode() {
+	return compileBitcode;
+    }
+
+    @DataBoundSetter
+    public void setCompileBitcode(Boolean compileBitcode) {
+	this.compileBitcode = compileBitcode;
+    }
+
+    @CheckForNull
+    public String getThinning() {
+	return thinning;
+    }
+
+    @DataBoundSetter
+    public void setThinning(String thinning) {
+	this.thinning = thinning;
+    }
+
+    public Boolean getAssetPacksInBundle() {
+	return embedOnDemandResourcesAssetPacksInBundle;
+    }
+
+    @DataBoundSetter
+    public void setAssetPacksInBundle(Boolean assetPacksInBundle) {
+	this.embedOnDemandResourcesAssetPacksInBundle = assetPacksInBundle;
+    }
+
+    @CheckForNull
+    public String getAssetPacksBaseURL() {
+	return onDemandResourcesAssetPacksBaseURL;
+    }
+
+    @DataBoundSetter
+    public void setAssetPacksBaseURL(String assetPacksBaseURL) {
+	this.onDemandResourcesAssetPacksBaseURL = assetPacksBaseURL;
+    }
+
+    @CheckForNull
+    public String getAppURL() {
+	return appURL;
+    }
+
+    @DataBoundSetter
+    public void setAppURL(String appURL) {
+	this.appURL = appURL;
+    }
+
+    @CheckForNull
+    public String getDisplayImageURL() {
+	return displayImageURL;
+    }
+
+    @DataBoundSetter
+    public void setDisplayImageURL(String displayImageURL) {
+	this.displayImageURL = displayImageURL;
+    }
+
+    @CheckForNull
+    public String getFullSizeImageURL() {
+	return fullSizeImageURL;
+    }
+
+    @DataBoundSetter
+    public void setFullSizeImageURL(String fullSizeImageURL) {
+	this.fullSizeImageURL = fullSizeImageURL;
+    }
+
+    @CheckForNull
+    public String getAssetPackManifestURL() {
+	return assetPackManifestURL;
+    }
 
     public void setSkipBuildStep(Boolean skipBuildStep) {
         this.skipBuildStep = skipBuildStep;
@@ -290,6 +763,11 @@ public class XCodeBuilder extends Builder implements SimpleBuildStep {
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
+    public XCodeBuilder() {
+	this.skipBuildStep = false;
+    }
+
+    @Deprecated
     public XCodeBuilder(Boolean buildIpa, Boolean generateArchive, Boolean noConsoleLog, String logfileOutputDirectory, Boolean cleanBeforeBuild, 
     		Boolean cleanTestReports, String configuration,
     		String target, String sdk, String xcodeProjectPath, String xcodeProjectFile, String xcodebuildArguments,
@@ -303,7 +781,7 @@ public class XCodeBuilder extends Builder implements SimpleBuildStep {
 		Boolean embedOnDemandResourcesAssetPacksInBundle, String onDemandResourcesAssetPacksBaseURL,
 		String appURL, String displayImageURL, String fullSizeImageURL,
 		String assetPackManifestURL) {
-
+	this();
         this.buildIpa = buildIpa;
         this.generateArchive = generateArchive;
         this.noConsoleLog = noConsoleLog;


### PR DESCRIPTION
…DataBoundConstructor to get parameters.
Since original code using @DataBoundConstructor to get the parameters, it could not omit the parameter when using "Blue Ocean Pipeline Editor" etc.

Currently, by using @DataBoundSetter instead of @DataBoundConstructor to acquire parameters, we improved the compatibility for Pipeline.