### PR TITLE
Fix display bug developer profil credentials

### DIFF
--- a/src/main/java/au/com/rayh/DeveloperProfile.java
+++ b/src/main/java/au/com/rayh/DeveloperProfile.java
@@ -122,7 +122,7 @@ public class DeveloperProfile extends BaseStandardCredentials {
     }
 
     @Extension
-    public static class DescriptorImpl extends CredentialsDescriptor {
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
         @Override
         public String getDisplayName() {
             return "Apple Developer Profile";

--- a/src/main/java/au/com/rayh/DeveloperProfile.java
+++ b/src/main/java/au/com/rayh/DeveloperProfile.java
@@ -31,7 +31,6 @@ import jenkins.security.ConfidentialKey;
 import org.apache.commons.fileupload.FileItem;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import com.cloudbees.plugins.credentials.CredentialsDescriptor;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 


### PR DESCRIPTION
This is a correction of the display bug on the "Apple Developer Profile" credentials form.

Before :
![bug_xcode](https://user-images.githubusercontent.com/4113567/57540237-8ce46d80-734c-11e9-8346-ee51c35cea9b.PNG)

After :
![bug_xcode_corrected](https://user-images.githubusercontent.com/4113567/57540636-6e32a680-734d-11e9-9bcc-a52146a9fe7f.PNG)

