### PR TITLE
Use GitHub as source of documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <packaging>hpi</packaging>
   <name>Xcode integration</name>
   <description>This plugin adds the ability to call Xcode command line tools to automate build and packaging iOS applications (iPhone, iPad, ...).</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Xcode+Plugin</url>
+  <url>https://github.com/jenkinsci/xcode-plugin</url>
   <licenses>
     <license>
       <name>MIT</name>


### PR DESCRIPTION
The Wiki is now being migrated to plugins.jenkins.io, the plugin docs can be hosted on GitHub (no copy-paste between wiki and GitHub needed anymore). See https://issues.jenkins-ci.org/browse/WEBSITE-637