### PR TITLE
Modernize plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     </developer>
   </developers>
   <scm>
-    <connection>scm:git:git@github.com:jenkinsci/xcode-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/xcode-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/xcode-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/xcode-plugin</url>
     <tag>xcode-plugin-2.0.11</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -130,19 +130,16 @@
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15on -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>1.69</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>2.3.1</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jaxb</artifactId>
-      <version>2.3.0.1</version>
+      <version>2.3.6-1</version>
     </dependency>
   </dependencies>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>1.69</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.40</version>
     <relativePath />
   </parent>
   <artifactId>xcode-plugin</artifactId>
@@ -146,7 +146,6 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/xcode-plugin</gitHubRepo>
     <jenkins.version>2.289.1</jenkins.version>
-    <java.level>8</java.level>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
-        <version>1008.vb9e22885c9cf</version>
+        <artifactId>bom-2.319.x</artifactId>
+        <version>1362.v59f2f3db_80ee </version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -145,7 +145,7 @@
     <revision>2.0.16</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/xcode-plugin</gitHubRepo>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.319.1</jenkins.version>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>com.googlecode.plist</groupId>
       <artifactId>dd-plist</artifactId>
-      <version>1.20</version>
+      <version>1.23</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.26</version>
+    <version>4.31</version>
     <relativePath />
   </parent>
   <artifactId>xcode-plugin</artifactId>
@@ -84,21 +84,29 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.289.x</artifactId>
+        <version>1008.vb9e22885c9cf</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.18</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
-      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.16</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -109,27 +117,41 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
-      <version>1.16</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-extensions</artifactId>
-      <version>1.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
-      <version>1.2.1</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15on -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.69</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.5</version>
     </dependency>
   </dependencies>
   <properties>
-    <jenkins.version>1.625.1</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.289.1</jenkins.version>
+    <java.level>8</java.level>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.69</version>
+      <version>1.70</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <relativePath />
   </parent>
   <artifactId>xcode-plugin</artifactId>
-  <version>2.0.16-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>Xcode integration</name>
   <description>This plugin adds the ability to call Xcode command line tools to automate build and packaging iOS applications (iPhone, iPad, ...).</description>
@@ -67,10 +67,10 @@
     </developer>
   </developers>
   <scm>
-    <connection>scm:git:https://github.com/jenkinsci/xcode-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/xcode-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/xcode-plugin</url>
-    <tag>xcode-plugin-2.0.11</tag>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>${scmTag}</tag>
   </scm>
   <repositories>
     <repository>
@@ -142,6 +142,9 @@
     </dependency>
   </dependencies>
   <properties>
+    <revision>2.0.16</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/xcode-plugin</gitHubRepo>
     <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -136,14 +136,9 @@
       <version>1.69</version>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.5</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jaxb</artifactId>
+      <version>2.3.0.1</version>
     </dependency>
   </dependencies>
   <properties>

--- a/src/main/java/au/com/rayh/DeveloperProfile.java
+++ b/src/main/java/au/com/rayh/DeveloperProfile.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
@@ -82,7 +82,7 @@ public class DeveloperProfile extends BaseStandardCredentials {
      * @throws IOException file I/O
      * @throws GeneralSecurityException Certificate error
      */
-    public @Nonnull List<X509Certificate> getCertificates() throws IOException, GeneralSecurityException {
+    public @NonNull List<X509Certificate> getCertificates() throws IOException, GeneralSecurityException {
         try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(getImage()))) {
             List<X509Certificate> r = new ArrayList<>();
 

--- a/src/main/java/au/com/rayh/DeveloperProfileLoader.java
+++ b/src/main/java/au/com/rayh/DeveloperProfileLoader.java
@@ -37,8 +37,8 @@ import org.kohsuke.stapler.QueryParameter;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -143,7 +143,7 @@ public class DeveloperProfileLoader extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+    public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
 	EnvVars envs = run.getEnvironment(listener);
 	String _profileId = envs.expand(this.profileId);
         String _keychainId = envs.expand(this.keychainId);

--- a/src/main/java/au/com/rayh/ExportIpa.java
+++ b/src/main/java/au/com/rayh/ExportIpa.java
@@ -18,7 +18,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.inject.Inject;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/au/com/rayh/GlobalConfigurationImpl.java
+++ b/src/main/java/au/com/rayh/GlobalConfigurationImpl.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.servlet.ServletException;
 
 /**

--- a/src/main/java/au/com/rayh/KeychainPasswordAndPathBinding.java
+++ b/src/main/java/au/com/rayh/KeychainPasswordAndPathBinding.java
@@ -37,7 +37,7 @@ import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -97,7 +97,7 @@ public class KeychainPasswordAndPathBinding extends MultiBinding<KeychainPasswor
     }
 
     @Override
-    public MultiEnvironment bind(@Nonnull Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    public MultiEnvironment bind(@NonNull Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
         KeychainPasswordAndPath credential = getCredentials(build);
         Map<String,String> m = new HashMap<String,String>();
         m.put(keychainPathVariable, credential.getKeychainPath());

--- a/src/main/java/au/com/rayh/KeychainPasswordAndPathImpl.java
+++ b/src/main/java/au/com/rayh/KeychainPasswordAndPathImpl.java
@@ -37,7 +37,6 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -62,7 +61,6 @@ public class KeychainPasswordAndPathImpl extends BaseStandardCredentials impleme
     /**
      * The flag for keychain in search path.
      */
-    @Nullable
     private String inSearchPath;
 
     /**

--- a/src/main/java/au/com/rayh/KeychainUnlockStep.java
+++ b/src/main/java/au/com/rayh/KeychainUnlockStep.java
@@ -24,8 +24,8 @@ import org.kohsuke.stapler.QueryParameter;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.inject.Inject;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -105,7 +105,7 @@ public class KeychainUnlockStep extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+    public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
 	EnvVars envs = run.getEnvironment(listener);
 	String _keychainId = envs.expand(this.keychainId);
         String _keychainName = envs.expand(this.keychainName);

--- a/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
+++ b/src/main/java/au/com/rayh/XCodeBuildOutputParser.java
@@ -242,7 +242,7 @@ public class XCodeBuildOutputParser {
         if(m.matches()) {
             requireTestSuite(m.group(1));
             requireTestCase(m.group(2));
-            currentTestCase.setTime(Float.valueOf(m.group(3)));
+            currentTestCase.setTime(Float.parseFloat(m.group(3)));
             currentTestSuite.getTestCases().add(currentTestCase);
             currentTestSuite.addTest();
 	    // Actually, I think that the test case should be closed and deleted here.
@@ -302,7 +302,7 @@ public class XCodeBuildOutputParser {
             requireTestCase(m.group(2));
             currentTestSuite.addTest();
             currentTestSuite.addFailure();
-            currentTestCase.setTime(Float.valueOf(m.group(3)));
+            currentTestCase.setTime(Float.parseFloat(m.group(3)));
             currentTestSuite.getTestCases().add(currentTestCase);
 	    //currentTestSuite.getTestCasesHash().remove(m.group(2));
 	    currentTestCase = null;

--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -57,7 +57,7 @@ import org.kohsuke.stapler.QueryParameter;
 import jenkins.model.Jenkins;
 
 import javax.inject.Inject;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectStreamException;

--- a/src/main/java/au/com/rayh/XcodeCredentialsHelper.java
+++ b/src/main/java/au/com/rayh/XcodeCredentialsHelper.java
@@ -8,8 +8,7 @@ import hudson.security.ACL;
 import hudson.util.ListBoxModel;
 import org.apache.commons.lang.StringUtils;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.Collections;
 
 /**
@@ -20,7 +19,7 @@ public class XcodeCredentialsHelper {
     private XcodeCredentialsHelper() {}
 
     @CheckForNull
-    public static KeychainPasswordAndPath getCredentials(@Nullable String credentialsId, ItemGroup context) {
+    public static KeychainPasswordAndPath getCredentials(String credentialsId, ItemGroup context) {
         if (StringUtils.isBlank(credentialsId)) {
             return null;
         }

--- a/src/main/java/au/com/rayh/XcodeDeclarativeCredentialsHandler.java
+++ b/src/main/java/au/com/rayh/XcodeDeclarativeCredentialsHandler.java
@@ -40,16 +40,6 @@ public class XcodeDeclarativeCredentialsHandler extends CredentialsBindingHandle
 
     @Nonnull
     @Override
-    public List<MultiBinding<KeychainPasswordAndPath>> toBindings(String varName, String credentialsId) {
-        return Collections.singletonList((MultiBinding<KeychainPasswordAndPath>)new KeychainPasswordAndPathBinding(
-                varName,
-                null,
-                null,
-                credentialsId));
-    }
-
-    @Nonnull
-    @Override
     public Class<? extends StandardCredentials> type() {
         return KeychainPasswordAndPath.class;
     }

--- a/src/main/java/au/com/rayh/XcodeDeclarativeCredentialsHandler.java
+++ b/src/main/java/au/com/rayh/XcodeDeclarativeCredentialsHandler.java
@@ -28,7 +28,7 @@ import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.Extension;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.CredentialsBindingHandler;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -37,13 +37,13 @@ import java.util.Map;
 @Extension
 public class XcodeDeclarativeCredentialsHandler extends CredentialsBindingHandler<KeychainPasswordAndPath> {
 
-    @Nonnull
+    @NonNull
     @Override
     public Class<? extends StandardCredentials> type() {
         return KeychainPasswordAndPath.class;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public List<Map<String, Object>> getWithCredentialsParameters(String credentialsId) {
         Map<String, Object> map = new HashMap<>();

--- a/src/main/java/au/com/rayh/XcodeProjectParser.java
+++ b/src/main/java/au/com/rayh/XcodeProjectParser.java
@@ -67,9 +67,6 @@ public class XcodeProjectParser {
 	for ( FilePath schemeFilesDir : schemeFilesDirList ) {
 	    try {
 		List<FilePath> files = schemeFilesDir.list(new XcodeSchemeFileFilter());
-		if ( files == null ) {
-		    return null;
-		}
 		for ( FilePath file : files ) {
 		    ProjectScheme scheme = parseXcodeScheme(file);
 		    String schemeName = file.getBaseName().replaceAll(".xcscheme$", "");


### PR DESCRIPTION
## Modernize plugin

Use the hints from the DevOps World 2021 ["Contributing to Open Source" workshop](https://docs.google.com/document/d/1PKYIpPlRVGsBqrz0Ob1Cv3cefOZ5j2xtGZdWs27kLuw/edit?usp=sharing) to modernize the plugin.  Modernizations include requiring Jenkins 2.319.1 or later, using the most recent parent pom, using the jaxb plugin, and resolving the spotbugs warning messages that are reported based on the updated dependencies.

* Avoid temporary Java object thru parseFloat
* Remove redundant null check
* Modernize plugin pom
* Remove useless pom comments
* Use jaxb plugin

Supersedes #111
